### PR TITLE
Add `omitempty` to Database Field

### DIFF
--- a/pkg/lib/fieldgroups/database/database.go
+++ b/pkg/lib/fieldgroups/database/database.go
@@ -9,7 +9,7 @@ import (
 
 // DatabaseFieldGroup represents the DatabaseFieldGroup config fields
 type DatabaseFieldGroup struct {
-	DbConnectionArgs *DbConnectionArgsStruct `default:"" validate:"" json:"DB_CONNECTION_ARGS" yaml:"DB_CONNECTION_ARGS"`
+	DbConnectionArgs *DbConnectionArgsStruct `default:"" validate:"" json:"DB_CONNECTION_ARGS,omitempty" yaml:"DB_CONNECTION_ARGS,omitempty"`
 	DbUri            string                  `default:"" validate:"" json:"DB_URI" yaml:"DB_URI"`
 }
 


### PR DESCRIPTION
### Description

Adds `omitempty` tag to the struct field for `DB_CONNECTION_ARGS`. Without this, it marshals to `null` which Quay can't handle on startup.

Blocks https://github.com/quay/quay-operator/pull/13