### PR TITLE
Omit Empty Fields in Distributed Storage

### DIFF
--- a/pkg/lib/fieldgroups/distributedstorage/distributedstorage.go
+++ b/pkg/lib/fieldgroups/distributedstorage/distributedstorage.go
@@ -33,11 +33,11 @@ func (ds DistributedStorage) MarshalJSON() ([]byte, error) {
 }
 
 type DistributedStorageArgs struct {
-	Hostname    string `default:"" validate:"" json:"hostname" yaml:"hostname"`
-	Port        int    `default:"{}" validate:"" json:"port" yaml:"port"`
-	IsSecure    bool   `default:"{}" validate:"" json:"is_secure" yaml:"is_secure"`
-	StoragePath string `default:"{}" validate:"" json:"storage_path" yaml:"storage_path"`
-	AccessKey   string `default:"{}" validate:"" json:"access_key" yaml:"access_key"`
-	SecretKey   string `default:"{}" validate:"" json:"secret_key" yaml:"secret_key"`
-	BucketName  string `default:"{}" validate:"" json:"bucket_name" yaml:"bucket_name"`
+	Hostname    string `default:"" validate:"" json:"hostname,omitempty" yaml:"hostname"`
+	Port        int    `default:"{}" validate:"" json:"port,omitempty" yaml:"port"`
+	IsSecure    bool   `default:"{}" validate:"" json:"is_secure,omitempty" yaml:"is_secure"`
+	StoragePath string `default:"{}" validate:"" json:"storage_path,omitempty" yaml:"storage_path"`
+	AccessKey   string `default:"{}" validate:"" json:"access_key,omitempty" yaml:"access_key"`
+	SecretKey   string `default:"{}" validate:"" json:"secret_key,omitempty" yaml:"secret_key"`
+	BucketName  string `default:"{}" validate:"" json:"bucket_name,omitempty" yaml:"bucket_name"`
 }


### PR DESCRIPTION
### Description

Quay fails with the default nil arguments for `DISTRIBUTED_STORAGE_CONFIG`. Add `omitempty` to the JSON tags for those structs.

**Error log from Quay**:
```sh
Traceback (most recent call last):
  File "/quay-registry/conf/init/data_migration.py", line 3, in <module>
    from app import app
  File "/quay-registry/app.py", line 237, in <module>
    storage = Storage(app, chunk_cleanup_queue, instance_keys, config_provider, ip_resolver)
  File "/quay-registry/storage/__init__.py", line 62, in __init__
    app, chunk_cleanup_queue, instance_keys, config_provider, ip_resolver
  File "/quay-registry/storage/__init__.py", line 71, in init_app
    location, chunk_cleanup_queue, config_provider, ip_resolver, storage_params,
  File "/quay-registry/storage/__init__.py", line 39, in get_storage_driver
    return driver_class(context, **parameters)
TypeError: __init__() got an unexpected keyword argument 'access_key'
```

Blocks https://issues.redhat.com/browse/PROJQUAY-830