### PR TITLE
Switch CLI Flags to Kebab-Case (PROJQUAY-1064)

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -5,7 +5,7 @@ tmp_dir = "tmp"
 # Just plain old shell command. You could use `make` as well.
 cmd = "cd /jssrc && yarn build && rm -rf /go/src/config-tool/pkg/lib/editor/static/build && mv /jssrc/static/build /go/src/config-tool/pkg/lib/editor/static/build && cd /go/src/config-tool && go build -o ./tmp/main ./cmd/..."
 # Binary file yields from `cmd`.
-bin = 'tmp/main editor --configDir=/conf --password=password --operatorEndpoint=https:////webhook.site/82875d14-4712-42d0-af6a-4ff451c924110'
+bin = 'tmp/main editor --config-dir=/conf --password=password --operator-endpoint=https:////webhook.site/82875d14-4712-42d0-af6a-4ff451c924110'
 # Watch these filename extensions.
 include_ext = ["go", "js", "html", "toml"]
 # Ignore these filename extensions or directories.

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 
 # Used to bring up production container
 run-local-prod:
-	sudo podman build -t config-app:latest -f Dockerfile . && sudo podman run -p 7070:8080 -v ${CONFIG_MOUNT}:/conf -ti config-app:latest editor --configDir=/conf --password=password --operatorEndpoint=${OPERATOR_ENDPOINT}
+	sudo podman build -t config-app:latest -f Dockerfile . && sudo podman run -p 7070:8080 -v ${CONFIG_MOUNT}:/conf -ti config-app:latest editor --config-dir=/conf --password=password --operator-endpoint=${OPERATOR_ENDPOINT}
 
 # Used to bring up dev container
 build-local-dev:

--- a/commands/editor.go
+++ b/commands/editor.go
@@ -37,15 +37,15 @@ func init() {
 	// Add editor command
 	rootCmd.AddCommand(editorCmd)
 
-	// Add --config flag
-	editorCmd.Flags().StringVarP(&configDir, "configDir", "c", "", "The directory containing your config files")
-	editorCmd.MarkFlagRequired("configDir")
+	// Add --config-dir flag
+	editorCmd.Flags().StringVarP(&configDir, "config-dir", "c", "", "The directory containing your config files")
+	editorCmd.MarkFlagRequired("config-dir")
 
 	// Add --password flag
 	editorCmd.Flags().StringVarP(&editorPassword, "password", "p", "", "The password to enter the editor")
 	editorCmd.MarkFlagRequired("password")
 
-	// Add --operatorEndpoint flag
-	editorCmd.Flags().StringVarP(&operatorEndpoint, "operatorEndpoint", "e", "", "The endpoint to commit a validated config bundle to")
-	editorCmd.MarkFlagRequired("operatorEndpoint")
+	// Add --operator-endpoint flag
+	editorCmd.Flags().StringVarP(&operatorEndpoint, "operator-endpoint", "e", "", "The endpoint to commit a validated config bundle to")
+	editorCmd.MarkFlagRequired("operator-endpoint")
 }


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1064

**Changelog:** Switch `--configDir` and `--operatorEndpoint` to use `--kebab-case`.

**Docs:** N/a

**Testing:** N/a

**Details:** Switches command-line flags to use `--kebab-case`. 
