### PR TITLE
Read-Only FieldGroups for Config Editor (PROJQUAY-909)

### DIFF
--- a/commands/editor.go
+++ b/commands/editor.go
@@ -16,12 +16,16 @@ limitations under the License.
 package commands
 
 import (
-	"github.com/quay/config-tool/pkg/lib/editor"
+	"strings"
+
 	"github.com/spf13/cobra"
+
+	"github.com/quay/config-tool/pkg/lib/editor"
 )
 
 var editorPassword string
 var operatorEndpoint string
+var readonlyFieldGroups string
 
 // editorCmd represents the validate command
 var editorCmd = &cobra.Command{
@@ -29,7 +33,7 @@ var editorCmd = &cobra.Command{
 	Short: "Runs a browser-based editor for your config.yaml",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		editor.RunConfigEditor(editorPassword, configDir, operatorEndpoint)
+		editor.RunConfigEditor(editorPassword, configDir, operatorEndpoint, strings.Split(readonlyFieldGroups, ","))
 	},
 }
 
@@ -48,4 +52,8 @@ func init() {
 	// Add --operator-endpoint flag
 	editorCmd.Flags().StringVarP(&operatorEndpoint, "operator-endpoint", "e", "", "The endpoint to commit a validated config bundle to")
 	editorCmd.MarkFlagRequired("operator-endpoint")
+
+	// Add --readonly-fieldgroups flag
+	editorCmd.Flags().StringVarP(&readonlyFieldGroups, "readonly-fieldgroups", "r", "", "Comma-separated list of fieldgroups that should be treated as read-only")
+	editorCmd.MarkFlagRequired("readonly-fieldgroups")
 }

--- a/pkg/lib/editor/js/config-field-templates/config-bool-field.html
+++ b/pkg/lib/editor/js/config-field-templates/config-bool-field.html
@@ -1,8 +1,8 @@
 <div class="config-bool-field-element">
   <form name="fieldform" novalidate>
     <label>
-        <input type="checkbox" ng-model="binding">
-        <span ng-transclude/>
+        <input type="checkbox" ng-model="binding" ng-disabled="isReadonly">
+        <span ng-transclude />
     </label>
   </form>
 </div>

--- a/pkg/lib/editor/js/config-field-templates/config-file-field.html
+++ b/pkg/lib/editor/js/config-field-templates/config-file-field.html
@@ -5,7 +5,7 @@
         <span style="margin-left: 20px; display: inline-block;">Select a replacement file:</span>
     </span>
     <span class="nofile" ng-if="!hasFile && skipCheckFile != 'true'">Please select a file to upload as <b>{{ filename }}</b>: </span>
-    <input type="file" ng-file-select="onFileSelect($files)">
+    <input type="file" ng-file-select="onFileSelect($files)" ng-disabled="isReadonly">
   </span>
   <span ng-show="uploadProgress != null">
     Uploading file as <strong>{{ filename }}</strong>... {{ uploadProgress }}%

--- a/pkg/lib/editor/js/config-field-templates/config-numeric-field.html
+++ b/pkg/lib/editor/js/config-field-templates/config-numeric-field.html
@@ -2,6 +2,6 @@
   <form name="fieldform" novalidate>
     <input type="number" class="form-control" placeholder="{{ placeholder || '' }}"
            ng-model="bindinginternal" ng-trim="false" ng-minlength="1" required
-           ng-readonly="::isReadonly">
+           ng-readonly="isReadonly">
   </form>
 </div>

--- a/pkg/lib/editor/js/config-field-templates/config-password-field.html
+++ b/pkg/lib/editor/js/config-field-templates/config-password-field.html
@@ -1,7 +1,7 @@
 <div class="config-password-field-element">
   <form name="fieldform" novalidate>
     <input type="password" class="form-control" placeholder="{{ placeholder || '' }}"
-           ng-model="binding" ng-trim="false" ng-minlength="1" ng-required="!isOptional">
+           ng-model="binding" ng-trim="false" ng-minlength="1" ng-required="!isOptional" ng-disabled="isReadonly">
     <div class="alert alert-danger" ng-show="errorMessage">
         {{ errorMessage }}
     </div>

--- a/pkg/lib/editor/js/config-field-templates/config-string-field.html
+++ b/pkg/lib/editor/js/config-field-templates/config-string-field.html
@@ -3,7 +3,7 @@
     <input type="text" class="form-control" placeholder="{{ placeholder || '' }}"
            ng-model="binding" ng-trim="false" ng-minlength="1"
            ng-pattern="getRegexp(pattern)" ng-required="!isOptional"
-           ng-readonly="::isReadonly">
+           ng-readonly="isReadonly">
     <div class="alert alert-danger" ng-show="errorMessage">
         {{ errorMessage }}
     </div>

--- a/pkg/lib/editor/js/config-field-templates/config-string-list-field.html
+++ b/pkg/lib/editor/js/config-field-templates/config-string-list-field.html
@@ -1,6 +1,6 @@
 <div class="config-string-list-field-element">
   <form name="fieldform" novalidate>
     <input type="text" class="form-control" placeholder="{{ placeholder || '' }}"
-           ng-model="internalBinding" ng-trim="true" ng-minlength="1" ng-required="!isOptional">
+           ng-model="internalBinding" ng-trim="true" ng-minlength="1" ng-required="!isOptional" ng-disabled="isReadonly">
   </form>
 </div>

--- a/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
+++ b/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
@@ -76,10 +76,9 @@
         <div class="co-panel-body">
           <table class="config-table">
             <tr>
-                <div class="co-alert co-alert-danger" ng-if="isFieldReadonly('hostname')">
-                    The Hostname configuration is managed externally. These values
-                    cannot be changed.
-                </div>
+              <div class="co-alert co-alert-danger" ng-if="fieldGroupReadonly('HostSettings')">
+                The Hostname configuration is currently managed externally. <button class="btn btn-link" ng-click="changeFieldGroupReadonly('HostSettings', false)">Edit fields</button>
+              </div>
             </tr>
             <tr>
               <td>Server Hostname:</td>
@@ -93,17 +92,17 @@
                       binding="config.SERVER_HOSTNAME"
                       placeholder="Hostname (and optional port if non-standard)"
                       pattern="{{ HOSTNAME_REGEX }}"
-                      is-readonly="::isFieldReadonly('hostname')"></span>
+                      is-readonly="fieldGroupReadonly('HostSettings')"></span>
                 <div class="help-text">
                   The HTTP host (and optionally the port number if a non-standard HTTP/HTTPS port) of the location
-                  where the registry will be accessible on the network
+                  where the registry will be accessible on the network.
                 </div>
               </td>
             </tr>
             <tr>
               <td>TLS:</td>
               <td>
-                <select ng-disabled="::isFieldReadonly('hostname')" class="form-control" ng-model="mapped.TLS_SETTING">
+                <select ng-disabled="fieldGroupReadonly('HostSettings')" class="form-control" ng-model="mapped.TLS_SETTING">
                   <option value="internal-tls">Red Hat Quay handles TLS</option>
                   <option value="external-tls">My own load balancer handles TLS (Not Recommended)</option>
                   <option value="none">None (Not For Production)</option>
@@ -119,8 +118,7 @@
                   Terminating TLS outside of Red Hat Quay can result in unusual behavior if the external load balancer
                   is not
                   configured properly. <strong>This option is not recommended for simple setups</strong>. Please contact
-                  support
-                  if you encounter problems while using this option.
+                  support if you encounter problems while using this option.
                 </div>
 
                 <div class="co-alert co-alert-info" ng-if="mapped.TLS_SETTING == 'internal-tls'"
@@ -131,7 +129,7 @@
                   connections on this hostname.
                 </div>
 
-                <table class="config-table" ng-if="mapped.TLS_SETTING == 'internal-tls' && !isFieldReadonly('hostname')">
+                <table class="config-table" ng-if="mapped.TLS_SETTING == 'internal-tls' && !fieldGroupReadonly('HostSettings')">
                   <tr>
                     <td class="non-input">Certificate:</td>
                     <td>
@@ -166,9 +164,14 @@
           </div>
           <table class="config-table">
             <tr>
+              <div class="co-alert co-alert-danger" ng-if="fieldGroupReadonly('Database')">
+                The database configuration is currently managed externally. <button class="btn btn-link" ng-click="changeFieldGroupReadonly('Database', false)">Edit fields</button>
+              </div>
+            </tr>
+            <tr>
               <td class="non-input">Database Type:</td>
               <td>
-                 <select ng-model="mapped.database.kind">
+                 <select ng-model="mapped.database.kind" ng-disabled="fieldGroupReadonly('Database')">
                     <option value="mysql+pymysql">MySQL</option>
                     <option value="postgresql">Postgres</option>
                  </select>
@@ -180,6 +183,7 @@
                 <span class="config-string-field" binding="mapped.database.server"
                       placeholder="dbserverhost"
                       pattern="{{ HOSTNAME_REGEX }}"
+                      is-readonly="fieldGroupReadonly('Database')"
                       validator="validateHostname(value)">></span>
                 <div class="help-text">
                   The server (and optionally, custom port) where the database lives
@@ -190,6 +194,7 @@
               <td>Username:</td>
               <td>
                 <span class="config-string-field" binding="mapped.database.username"
+                      is-readonly="fieldGroupReadonly('Database')"
                       placeholder="someuser"></span>
                 <div class="help-text">This user must have <strong>full access</strong> to the database</div>
               </td>
@@ -197,13 +202,14 @@
             <tr ng-show="mapped.database.kind">
               <td>Password:</td>
               <td>
-                <input class="form-control" type="password" ng-model="mapped.database.password">
+                <input class="form-control" type="password" ng-model="mapped.database.password" ng-disabled="fieldGroupReadonly('Database')">
               </td>
             </tr>
             <tr ng-show="mapped.database.kind">
               <td>Database Name:</td>
               <td>
                 <span class="config-string-field" binding="mapped.database.database"
+                      is-readonly="fieldGroupReadonly('Database')"
                       placeholder="registry-database"></span>
               </td>
             </tr>
@@ -211,6 +217,7 @@
               <td>SSL Certificate:</td>
               <td>
                 <span class="config-file-field" filename="database.pem"
+                      is-readonly="fieldGroupReadonly('Database')"
                       skip-check-file="true" has-file="currentState.hasDatabaseSSLCert"></span>
                 <div class="help-text">Optional SSL certicate (in PEM format) to use to connect to the database</div>
               </td>
@@ -314,13 +321,11 @@
             <p>A <a href="http://redis.io" ng-safenewtab>redis</a> key-value store is required for real-time events and
               build logs.</p>
           </div>
-
           <table class="config-table">
             <tr>
-                <div class="co-alert co-alert-danger" ng-if="isFieldReadonly('redis')">
-                    The Redis configuration is managed externally. These values
-                    cannot be changed.
-                </div>
+              <div class="co-alert co-alert-danger" ng-if="fieldGroupReadonly('Redis')">
+                The Redis configuration is currently managed externally. <button class="btn btn-link" ng-click="changeFieldGroupReadonly('Redis', false)">Edit fields</button>
+              </div>
             </tr>
             <tr>
               <td>Redis Hostname:</td>
@@ -330,7 +335,7 @@
                       placeholder="The redis server hostname"
                       pattern="{{ HOSTNAME_REGEX }}"
                       validator="validateHostname(value)"
-                      is-readonly="::isFieldReadonly('redis')"></span>
+                      is-readonly="fieldGroupReadonly('Redis')"></span>
               </td>
             </tr>
             <tr>
@@ -339,7 +344,7 @@
                 <span class="config-numeric-field"
                       binding="mapped.redis.port"
                       default-value="6379"
-                      is-readonly="::isFieldReadonly('redis')"></span>
+                      is-readonly="fieldGroupReadonly('Redis')"></span>
                 <div class="help-text">
                   Access to this port and hostname must be allowed from all hosts running
                   the enterprise registry
@@ -353,7 +358,7 @@
                        type="password"
                        ng-model="mapped.redis.password"
                        placeholder="Optional password for connecting to redis"
-                       ng-readonly="::isFieldReadonly('redis')">
+                       ng-readonly="fieldGroupReadonly('Redis')">
               </td>
             </tr>
           </table>
@@ -396,9 +401,12 @@
               <div class="co-alert co-alert-danger">
                 Do not use "Locally mounted directory" Storage Engine for any production configurations. Mounted NFS volumes are not supported. Local storage is meant for test-only installations.
               </div>
+              <div class="co-alert co-alert-danger" ng-if="fieldGroupReadonly('DistributedStorage')">
+                The registry storage configuration is currently managed externally. <button class="btn btn-link" ng-click="changeFieldGroupReadonly('DistributedStorage', false)">Edit fields</button>
+              </div>
             </p>
 
-            <div class="config-bool-field" binding="config.FEATURE_PROXY_STORAGE">
+            <div class="config-bool-field" binding="config.FEATURE_PROXY_STORAGE" is-readonly="fieldGroupReadonly('DistributedStorage')">
               Proxy storage via <span class="registry-name"></span>
               <div class="help-text">
                 If enabled, all requests to storage engine(s) will be proxied through
@@ -407,7 +415,7 @@
               </div>
             </div>
 
-            <div class="config-bool-field feature-storage-replication" binding="config.FEATURE_STORAGE_REPLICATION">
+            <div class="config-bool-field feature-storage-replication" binding="config.FEATURE_STORAGE_REPLICATION" is-readonly="fieldGroupReadonly('DistributedStorage')">
               Enable Storage Replication
               <div class="help-text">
                 If enabled, replicates storage to other regions. See
@@ -423,7 +431,7 @@
                   <td>
                     <input class="form-control" ng-if="allowChangeLocationStorageConfig(sc.location)"
                            ng-class="storageConfigError[$index].location ? 'ng-invalid' : ''" ng-model="sc.location"
-                           ng-pattern="/^[a-zA-Z0-9_-]+$/" required>
+                           ng-pattern="/^[a-zA-Z0-9_-]+$/" ng-disabled="fieldGroupReadonly('DistributedStorage')" required>
                     <div ng-if="!allowChangeLocationStorageConfig(sc.location)">
                       {{ sc.location }}
                     </div>
@@ -438,7 +446,7 @@
                 <tr ng-if="config.FEATURE_STORAGE_REPLICATION">
                   <td class="non-input">Set Default:</td>
                   <td>
-                    <div class="config-bool-field" binding="sc.defaultLocation">
+                    <div class="config-bool-field" binding="sc.defaultLocation" is-readonly="fieldGroupReadonly('DistributedStorage')">
                       Replicate to storage engine by default
                     </div>
                   </td>
@@ -448,7 +456,7 @@
                   <td class="non-input">Storage Engine:</td>
                   <td>
                     <select class="form-control" ng-class="storageConfigError[$index].engine ? 'ng-invalid' : ''"
-                            ng-model="sc.data[0]">
+                            ng-model="sc.data[0]" ng-disabled="fieldGroupReadonly('DistributedStorage')">
                       <option value="RHOCSStorage">Red Hat OpenShift Container Storage (NooBaa S3)</option>
                       <option value="LocalStorage">Locally mounted directory</option>
                       <option value="S3Storage">Amazon S3</option>
@@ -470,22 +478,23 @@
                   <td>{{ field.title }}:</td>
                   <td>
                     <span class="config-map-field" binding="sc.data[1][field.name]" ng-if="field.kind == 'map'"
-                          keys="field.keys"></span>
+                          keys="field.keys" is-readonly="fieldGroupReadonly('DistributedStorage')"></span>
                     <span class="config-string-field" binding="sc.data[1][field.name]"
                           placeholder="{{ field.placeholder }}" pattern="{{ field.pattern }}" ng-if="field.kind == 'text'"
-                          is-optional="field.optional"></span>
+                          is-optional="field.optional" is-readonly="fieldGroupReadonly('DistributedStorage')"></span>
                     <span class="config-password-field" binding="sc.data[1][field.name]"
                           placeholder="{{ field.placeholder }}" pattern="{{ field.pattern }}" ng-if="field.kind == 'password'"
-                          is-optional="field.optional"></span>
-                    <span class="config-bool-field" binding="sc.data[1][field.name]" ng-if="field.kind == 'bool'">
+                          is-optional="field.optional" is-readonly="fieldGroupReadonly('DistributedStorage')"></span>
+                    <span class="config-bool-field" binding="sc.data[1][field.name]" ng-if="field.kind == 'bool'" is-readonly="fieldGroupReadonly('DistributedStorage')">
                       {{ field.placeholder }}
                     </span>
                     <span class="config-file-field" filename="{{ sc.location + '-' + field.filesuffix }}"
                           binding="sc.data[1][field.name]"
                           has-file="hasfile['contact-' + sc.location + '-' + field.filesuffix]"
-                          ng-if="field.kind == 'file'"></span>
+                          ng-if="field.kind == 'file'"
+                          is-readonly="fieldGroupReadonly('DistributedStorage')"></span>
                     <div ng-if="field.kind == 'option'">
-                      <select class="form-control" ng-model="sc.data[1][field.name]">
+                      <select class="form-control" ng-model="sc.data[1][field.name]" ng-disabled="fieldGroupReadonly('DistributedStorage')">
                         <option ng-repeat="value in field.values" value="{{ value }}"
                                 ng-selected="sc.data[1][field.name] == value">{{ value }}</option>
                       </select>
@@ -556,32 +565,28 @@
               <td>Elasticsearch access key:</td>
               <td>
                 <span class="config-string-field" binding="mapped.LOGS_MODEL_CONFIG.elasticsearch_config.access_key"
-                      placeholder="The Elasticsearch access key"
-                </span>
+                      placeholder="The Elasticsearch access key"></span>
               </td>
             </tr>
             <tr>
               <td>Elasticsearch secret key:</td>
               <td>
                 <span class="config-password-field" binding="mapped.LOGS_MODEL_CONFIG.elasticsearch_config.secret_key"
-                      placeholder="The Elasticsearch secret key"
-                </span>
+                      placeholder="The Elasticsearch secret key"></span>
               </td>
             </tr>
             <tr>
               <td>AWS region:</td>
               <td>
                 <span class="config-string-field" binding="mapped.LOGS_MODEL_CONFIG.elasticsearch_config.aws_region"
-                      placeholder="The AWS region (optional)" is-optional="true"
-                </span>
+                      placeholder="The AWS region (optional)" is-optional="true"></span>
               </td>
             </tr>
             <tr>
               <td>Index prefix:</td>
               <td>
                 <span class="config-string-field" binding="mapped.LOGS_MODEL_CONFIG.elasticsearch_config.index_prefix"
-                      default-value="logentry_" placeholder="The Elasticsearch index_prefix"
-                </span>
+                      default-value="logentry_" placeholder="The Elasticsearch index_prefix"></span>
               </td>
             </tr>
             <tr>
@@ -602,32 +607,28 @@
               <td>Stream name:</td>
               <td>
                 <span class="config-string-field" binding="mapped.LOGS_MODEL_CONFIG.kinesis_stream_config.stream_name"
-                      placeholder="The Kinesis stream name"
-                </span>
+                      placeholder="The Kinesis stream name"></span>
               </td>
             </tr>
             <tr>
               <td>AWS access key:</td>
               <td>
                 <span class="config-string-field" binding="mapped.LOGS_MODEL_CONFIG.kinesis_stream_config.aws_access_key"
-                      placeholder="The AWS access key"
-                </span>
+                      placeholder="The AWS access key"></span>
               </td>
             </tr>
             <tr>
               <td>AWS secret key:</td>
               <td>
                 <span class="config-password-field" binding="mapped.LOGS_MODEL_CONFIG.kinesis_stream_config.aws_secret_key"
-                      placeholder="The AWS secret key"
-                </span>
+                      placeholder="The AWS secret key"></span>
               </td>
             </tr>
             <tr>
               <td>AWS region:</td>
               <td>
                 <span class="config-string-field" binding="mapped.LOGS_MODEL_CONFIG.kinesis_stream_config.aws_region"
-                      placeholder="The AWS region"
-                </span>
+                      placeholder="The AWS region"></span>
               </td>
             </tr>
           </table>
@@ -710,7 +711,11 @@
             </p>
           </div>
 
-          <div class="config-bool-field" binding="config.FEATURE_SECURITY_SCANNER">
+          <div class="co-alert co-alert-danger" ng-if="fieldGroupReadonly('SecurityScanner')">
+            The security scanner configuration is currently managed externally. <button class="btn btn-link" ng-click="changeFieldGroupReadonly('SecurityScanner', false)">Edit fields</button>
+          </div>
+
+          <div class="config-bool-field" binding="config.FEATURE_SECURITY_SCANNER" is-readonly="fieldGroupReadonly('SecurityScanner')">
             Enable Security Scanning
           </div>
           <div class="co-alert co-alert-info" ng-if="config.FEATURE_SECURITY_SCANNER" style="margin-top: 20px;">
@@ -727,7 +732,7 @@
               <td>
                 <span class="config-string-field" binding="config.SECURITY_SCANNER_V4_ENDPOINT"
                       placeholder="Security Scanner API endpoint (Example: http://myhost)"
-                      pattern="http(s)?://.+"></span>
+                      pattern="http(s)?://.+" is-readonly="fieldGroupReadonly('SecurityScanner')"></span>
                 <div class="help-text">
                   The HTTP URL at which the security scanner is running.
                 </div>
@@ -2061,7 +2066,6 @@
             <button class="btn btn-primary" ng-click="downloadConfig()">
               Download
             </button>
-            <!-- FIXME(alecmerdler): Only show if running under Operator -->
             <button class="btn btn-primary" ng-if="operatorEndpoint" ng-click="commitToOperator()">
               Reconfigure Quay
             </button>

--- a/pkg/lib/editor/js/services/api-service.js
+++ b/pkg/lib/editor/js/services/api-service.js
@@ -17,8 +17,12 @@ angular.module("quay-config").factory("ApiService", [
       return Restangular.one("config/validate").post(null, config);
     };
 
-    apiService.commitToOperator = function (config) {
-      return Restangular.one("config/commitToOperator").post(null, config);
+    apiService.commitToOperator = function (config, managedFieldGroups) {
+      return Restangular.one("config/commitToOperator")
+        .post(null, {
+          "config.yaml": config, 
+          "managedFieldGroups": managedFieldGroups
+        });
     };
 
     apiService.downloadConfig = function (config) {
@@ -32,7 +36,7 @@ angular.module("quay-config").factory("ApiService", [
     apiService.getErrorMessage = function (resp, defaultMessage) {
       var message = defaultMessage;
       if (resp && resp["data"]) {
-        //TODO: remove error_message and error_description (old style error)
+        // TODO: remove error_message and error_description (old style error)
         message =
           resp["data"]["detail"] ||
           resp["data"]["error_message"] ||

--- a/pkg/lib/fieldgroups/database/database.go
+++ b/pkg/lib/fieldgroups/database/database.go
@@ -15,14 +15,14 @@ type DatabaseFieldGroup struct {
 
 // DbConnectionArgsStruct represents the DbConnectionArgsStruct config fields
 type DbConnectionArgsStruct struct {
-	Ssl          *SslStruct `default:"{}" validate:"" json:"ssl" yaml:"ssl"`
+	Ssl          *SslStruct `default:"" validate:"" json:"ssl,omitempty" yaml:"ssl,omitempty"`
 	Threadlocals bool       `default:"true" validate:"" json:"threadlocals" yaml:"threadlocals"`
 	Autorollback bool       `default:"true" validate:"" json:"autorollback" yaml:"autorollback"`
 }
 
 // SslStruct represents the SslStruct config fields
 type SslStruct struct {
-	Ca string `default:"" validate:"" json:"ca" yaml:"ca"`
+	Ca string `default:"" validate:"" json:"ca,omitempty" yaml:"ca,omitempty"`
 }
 
 // NewDatabaseFieldGroup creates a new DatabaseFieldGroup

--- a/pkg/lib/fieldgroups/database/database_validator.go
+++ b/pkg/lib/fieldgroups/database/database_validator.go
@@ -46,8 +46,12 @@ func (fg *DatabaseFieldGroup) Validate(opts shared.Options) []shared.ValidationE
 		return errors
 	}
 
+	ca := ""
+	if fg.DbConnectionArgs.Ssl != nil {
+		ca = fg.DbConnectionArgs.Ssl.Ca
+	}
 	// Connect to database
-	err = ValidateDatabaseConnection(opts, uri, fg.DbConnectionArgs.Ssl.Ca)
+	err = ValidateDatabaseConnection(opts, uri, ca)
 	if err != nil {
 		newError := shared.ValidationError{
 			Tags:       []string{"DB_URI"},


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-909

**Changelog:** Allow passing `--readonly-fieldgroups` to config editor.

**Docs:** N/a

**Testing:** TODO(alecmerdler)

**Details:** Adds `--readonly-fieldgroups` flag to config editor. Primarily will be used by Quay Operator to indicate in the editor UI that managed components are responsible for their config fields.

