### PR TITLE
Storage Proxy Field (PROJQUAY-1087)

### DIFF
--- a/pkg/lib/fieldgroups/distributedstorage/distributedstorage.go
+++ b/pkg/lib/fieldgroups/distributedstorage/distributedstorage.go
@@ -15,6 +15,7 @@ type DistributedStorageFieldGroup struct {
 	DistributedStoragePreference       []string                                 `default:"[]" validate:"" json:"DISTRIBUTED_STORAGE_PREFERENCE" yaml:"DISTRIBUTED_STORAGE_PREFERENCE"`
 	DistributedStorageDefaultLocations []string                                 `default:"[]" validate:"" json:"DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS" yaml:"DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS"`
 	FeatureStorageReplication          bool                                     `default:"false" validate:"" json:"FEATURE_STORAGE_REPLICATION" yaml:"FEATURE_STORAGE_REPLICATION"`
+	FeatureProxyStorage                bool                                     `default:"false" validate:"" json:"FEATURE_PROXY_STORAGE,omitempty" yaml:"FEATURE_PROXY_STORAGE,omitempty"`
 }
 
 // DistributedStorageDefinition represents a single storage configuration as a tuple (Name, Arguments)
@@ -36,7 +37,6 @@ func NewDistributedStorageFieldGroup(fullConfig map[string]interface{}) (*Distri
 	}
 
 	if value, ok := fullConfig["DISTRIBUTED_STORAGE_PREFERENCE"]; ok {
-
 		for _, element := range value.([]interface{}) {
 			strElement, ok := element.(string)
 			if !ok {
@@ -51,7 +51,6 @@ func NewDistributedStorageFieldGroup(fullConfig map[string]interface{}) (*Distri
 	}
 
 	if value, ok := fullConfig["DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS"]; ok {
-
 		for _, element := range value.([]interface{}) {
 			strElement, ok := element.(string)
 			if !ok {
@@ -66,11 +65,9 @@ func NewDistributedStorageFieldGroup(fullConfig map[string]interface{}) (*Distri
 	}
 
 	if value, ok := fullConfig["DISTRIBUTED_STORAGE_CONFIG"]; ok {
-
 		var err error
 		value := shared.FixInterface(value.(map[interface{}]interface{}))
 		for k, v := range value {
-
 			if _, ok := v.([]interface{}); !ok {
 				return newDistributedStorageFieldGroup, errors.New("DISTRIBUTED_STORAGE_CONFIG object values must be of form (Name, Args)")
 			}
@@ -110,7 +107,6 @@ func NewDistributedStorageDefinition(storageDef []interface{}) (*DistributedStor
 	}
 
 	return newDistributedStorageDefinition, nil
-
 }
 
 // NewDistributedStorageArgs creates a new DistributedStorageArgs type
@@ -168,7 +164,6 @@ func NewDistributedStorageArgs(storageArgs map[string]interface{}) (*shared.Dist
 	}
 
 	return newDistributedStorageArgs, nil
-
 }
 
 func (ds DistributedStorageDefinition) UnmarshalJSON(buf []byte) error {

--- a/utils/generate/not-done.json
+++ b/utils/generate/not-done.json
@@ -280,11 +280,6 @@
       "type": "array",
       "description": "The array of namespace names that support V1 push if FEATURE_RESTRICTED_V1_PUSH is set to true."
     },
-    "FEATURE_PROXY_STORAGE": {
-      "x-example": false,
-      "type": "boolean",
-      "description": "Whether to proxy all direct download URLs in storage via the registry nginx. Defaults to False"
-    },
     "DEFAULT_NAMESPACE_MAXIMUM_BUILD_COUNT": {
       "x-example": 20,
       "type": ["number", "null"],

--- a/utils/generate/schema.json
+++ b/utils/generate/schema.json
@@ -139,6 +139,14 @@
       "ct-validate": "",
       "ct-fieldgroups": ["ActionLogArchiving"]
     },
+    "FEATURE_PROXY_STORAGE": {
+      "x-example": false,
+      "type": "boolean",
+      "description": "Whether to proxy all direct download URLs in storage via the registry nginx. Defaults to False",
+      "ct-default": "false",
+      "ct-validate": "",
+      "ct-fieldgroups": ["DistributedStorage"]
+    },
     "DISTRIBUTED_STORAGE_CONFIG": {
       "x-example": {
         "local_storage": ["LocalStorage", { "storage_path": "some/path/" }]


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1087

**Changelog:** Adds the `FEATURE_PROXY_STORAGE` field.

**Docs:** N/a

**Testing:** N/a

**Details:** This field is needed to enable storage proxy through the Quay NGINX for https://issues.redhat.com/browse/PROJQUAY-1087.

