### PR TITLE
Change Default Port and Local Storage Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,5 @@ build-local-dev:
 	sudo podman build -t config-app:dev -f Dockerfile.dev
 
 run-local-dev:
-	sudo podman run -p 7070:8080 -v ./pkg/lib/editor/js:/jssrc/js -v ./pkg/lib/editor/editor.go:/jssrc/editor.go -v ./:/go/src/config-tool -v ${CONFIG_MOUNT}:/conf -e MY_POD_NAMESPACE=${MY_POD_NAMESPACE} -e MY_POD_NAME=${MY_POD_NAME} -ti config-app:dev
+	sudo podman run -p 7070:8443 -v ./pkg/lib/editor/js:/jssrc/js -v ./pkg/lib/editor/editor.go:/jssrc/editor.go -v ./:/go/src/config-tool -v ${CONFIG_MOUNT}:/conf -e MY_POD_NAMESPACE=${MY_POD_NAMESPACE} -e MY_POD_NAME=${MY_POD_NAME} -ti config-app:dev
 

--- a/pkg/lib/editor/editor.go
+++ b/pkg/lib/editor/editor.go
@@ -22,7 +22,7 @@ import (
 	shared "github.com/quay/config-tool/pkg/lib/shared"
 )
 
-const port = 8080
+const port = 8443
 const editorUsername = "quayconfig"
 
 func handler(staticContentPath, operatorEndpoint string) func(w http.ResponseWriter, r *http.Request) {
@@ -44,15 +44,6 @@ func handler(staticContentPath, operatorEndpoint string) func(w http.ResponseWri
 
 // commitToOperator calls API endpoint on Quay Operator to create a new `Secret`.
 func commitToOperator(configPath, operatorEndpoint string) func(w http.ResponseWriter, r *http.Request) {
-	namespace := os.Getenv("MY_POD_NAMESPACE")
-	if namespace == "" {
-		panic("missing 'MY_POD_NAMESPACE'")
-	}
-	podName := os.Getenv("MY_POD_NAME")
-	if podName == "" {
-		panic("missing 'MY_POD_NAME'")
-	}
-	quayRegistryName := strings.Split(podName, "-quay-config-editor")[0]
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
@@ -70,6 +61,16 @@ func commitToOperator(configPath, operatorEndpoint string) func(w http.ResponseW
 		for name, cert := range shared.LoadCerts(configPath) {
 			certStore[name] = cert
 		}
+
+		namespace := os.Getenv("MY_POD_NAMESPACE")
+		if namespace == "" {
+			panic("missing 'MY_POD_NAMESPACE'")
+		}
+		podName := os.Getenv("MY_POD_NAME")
+		if podName == "" {
+			panic("missing 'MY_POD_NAME'")
+		}
+		quayRegistryName := strings.Split(podName, "-quay-config-editor")[0]
 
 		// TODO: Define struct type for this with correct `yaml` tags
 		preSecret := map[string]interface{}{

--- a/pkg/lib/fieldgroups/distributedstorage/distributedstorage_validator.go
+++ b/pkg/lib/fieldgroups/distributedstorage/distributedstorage_validator.go
@@ -37,6 +37,7 @@ func (fg *DistributedStorageFieldGroup) Validate(opts shared.Options) []shared.V
 				Message:    "FEATURE_STORAGE_REPLICATION is not supported by LocalStorage.",
 			}
 			errors = append(errors, newError)
+			continue
 		}
 
 		if ok, err := shared.ValidateMinioStorage(opts, storageConf.Args, "DistributedStorage"); !ok {

--- a/pkg/lib/fieldgroups/distributedstorage/distributedstorage_validator.go
+++ b/pkg/lib/fieldgroups/distributedstorage/distributedstorage_validator.go
@@ -37,6 +37,10 @@ func (fg *DistributedStorageFieldGroup) Validate(opts shared.Options) []shared.V
 				Message:    "FEATURE_STORAGE_REPLICATION is not supported by LocalStorage.",
 			}
 			errors = append(errors, newError)
+		}
+
+		// Do not validate local storage (fix me?)
+		if storageConf.Name == "LocalStorage" {
 			continue
 		}
 


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-NA

**Changelog:** 
- Changed default port from 8080 to 8443 (to match original config app)
- Bypass s3 storage validation if storage is LocalStorage
- Namespace and name env variables checked INSIDE of operator call. This fixes the config-tool panicking outside of operator environment. 

**Docs:** 

**Testing:** 

**Details:** 

------