### PR TITLE
Handle Empty Config Mount (Setup)

### DIFF
--- a/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
+++ b/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
@@ -38,14 +38,14 @@
             <tr>
               <td class="non-input">Registry Title Short:</td>
               <td colspan="2">
-                <span class="config-string-field" binding="config.REGISTRY_TITLE_SHORT"></span>
+                <span class="config-string-field" binding="config.REGISTRY_TITLE_SHORT" is-optional="true"></span>
               </td>
             </tr>
             <tr>
               <td>Enterprise Logo URL:</td>
               <td>
                 <span class="config-string-field" binding="config.ENTERPRISE_LOGO_URL"
-                      placeholder="http://example.com/logo.png"></span>
+                      placeholder="http://example.com/logo.png" is-optional="true"></span>
                 <div class="help-text">
                   Enter the full URL to your company's logo.
                 </div>

--- a/pkg/lib/editor/js/core-config-setup/core-config-setup.js
+++ b/pkg/lib/editor/js/core-config-setup/core-config-setup.js
@@ -240,15 +240,15 @@ angular.module("quay-config")
               'Could not validate configuration. Please report this error.');
 
           ApiService.validateConfigBundle({"config.yaml": $scope.config, "certs": $scope.certs, readOnlyFieldGroups: $scope.readOnlyFieldGroups}).then(function(resp) {
-            $scope.validationStatus = resp.length == 0 ? 'success' : 'error';
-            $scope.validationResult = resp;
+            $scope.validationStatus = resp.data.length == 0 ? 'success' : 'error';
+            $scope.validationResult = resp.data;
           }, errorDisplay);
         };
 
         $scope.commitToOperator = function() {
           ApiService.commitToOperator({"config.yaml": $scope.config, "certs": $scope.certs, readOnlyFieldGroups: $scope.readOnlyFieldGroups}).then(function(resp) {
-            console.log(resp)
-          })
+            alert("Successfully sent config bundle to Quay Operator")
+          }, errorDisplay)
         }
 
         $scope.downloadConfigBundle = function() {
@@ -780,12 +780,16 @@ angular.module("quay-config")
           if (!value) { return; }
 
           ApiService.getMountedConfigBundle().then(function(resp) {
-            $scope.config = resp["config.yaml"] || {};
-            $scope.certs = resp["certs"] || {};
-            $scope.originalConfig = Object.assign({}, resp["config.yaml"] || {});;
+            console.log("resp",resp)
+            $scope.config = resp.data["config.yaml"] || {};
+            $scope.certs = resp.data["certs"] || {};
+            $scope.originalConfig = Object.assign({}, resp.data["config.yaml"] || {});;
             initializeMappedLogic($scope.config);
             initializeStorageConfig($scope);
             $scope.mapped['$hasChanges'] = false;
+            if(resp.status == 202){
+              alert("Warning: No config bundle was found. Default values will be used. \n If you are trying to modify an existing config bundle, please make sure that you are mounting it correctly.")
+            }
           }, ApiService.errorDisplay('Could not load config'));
         });
       }

--- a/pkg/lib/editor/js/services/api-service.js
+++ b/pkg/lib/editor/js/services/api-service.js
@@ -8,7 +8,8 @@ angular.module("quay-config").factory("ApiService", [
   "UtilService",
   function (Restangular, $q, UtilService) {
     var apiService = {};
-
+    Restangular.setFullResponse(true)
+    
     apiService.getMountedConfigBundle = function () {
       return Restangular.one("config").get();
     };


### PR DESCRIPTION

**Issue:** https://issues.redhat.com/browse/PROJQUAY-???
Pull-request title must start with "PROJQUAY-??? - "

**Changelog:** 

- The config editor will now display a warning when no config bundle is found. This replaces the behavior of failing and returning an error. This handles the situation in which new users do not have a valid config bundle yet but still need to access the config editor. 

- Removed logo url and registry short name from being required. 

**Docs:** 

**Testing:** 

**Details:** 

------
