### PR TITLE
[PROJQUAY-1149] fix: Use mysql+pymysql:// for MySQL DB_URI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,6 +44,14 @@ jobs:
           POSTGRES_DB: "quay"
       redis:
         image: redis:latest
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: quay
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
       jwt:
         image: quay.io/coreos/jwt-auth-example:latest
     steps:

--- a/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
+++ b/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
@@ -172,7 +172,7 @@
               <td class="non-input">Database Type:</td>
               <td>
                  <select ng-model="mapped.database.kind" ng-disabled="fieldGroupReadonly('Database')">
-                    <option value="mysql">MySQL</option>
+                    <option value="mysql+pymysql">MySQL</option>
                     <option value="postgresql">Postgres</option>
                  </select>
               </td>

--- a/pkg/lib/fieldgroups/database/database_test.go
+++ b/pkg/lib/fieldgroups/database/database_test.go
@@ -20,6 +20,10 @@ func TestValidateDatabase(t *testing.T) {
 		{name: "dbURIMissing", config: map[string]interface{}{"DB_URI": ""}, want: "invalid"},
 		{name: "dbURIInvalid", config: map[string]interface{}{"DB_URI": "not a url"}, want: "invalid"},
 		{name: "dbURIPostgres", config: map[string]interface{}{"DB_URI": "postgresql://user:password@postgres:5432/quay"}, want: "invalid"},
+
+		// Quay currently requires the pymysql library to be specified in the DB_URI
+		{name: "ValidMysqlURI", config: map[string]interface{}{"DB_URI": "mysql+pymysql://root:password@mysql:3306/quay"}, want: "valid"},
+		{name: "MissingPyMysql", config: map[string]interface{}{"DB_URI": "mysql://root:password@mysql:3306/quay"}, want: "invalid"},
 	}
 
 	// Iterate through tests

--- a/pkg/lib/fieldgroups/database/database_validator.go
+++ b/pkg/lib/fieldgroups/database/database_validator.go
@@ -89,7 +89,7 @@ func ValidateDatabaseConnection(opts shared.Options, uri *url.URL, caCert string
 	dbname := uri.Path[1:]
 
 	// Database is MySQL
-	if scheme == "mysql" {
+	if scheme == "mysql+pymysql" {
 
 		// Create db connection string
 		dsn := credentials + "@tcp(" + fullHostName + ")/" + dbname


### PR DESCRIPTION
**Issue:**
- https://issues.redhat.com/browse/PROJQUAY-1149

**Changelog:**

- Use `mysql+pymysql://` for MySQL's DB_URI

**Docs:** 
- n/a

**Testing:**
- The `config.yaml` generated by the config-tool should allow Quay to successfully connect to a MySQL server.

**Details:** 
- Quay currently requires the Python library `pymysql` to be explicitly mentioned when defining the connection string for MySQL.