### PR TITLE
set default gitlab endpoint

### DIFF
--- a/pkg/lib/fieldgroups/gitlabbuildtrigger/gitlabbuildtrigger.go
+++ b/pkg/lib/fieldgroups/gitlabbuildtrigger/gitlabbuildtrigger.go
@@ -15,7 +15,7 @@ type GitLabBuildTriggerFieldGroup struct {
 
 // GitlabTriggerConfigStruct represents the GitlabTriggerConfigStruct config fields
 type GitlabTriggerConfigStruct struct {
-	GitlabEndpoint string `default:"" validate:"" json:"GITLAB_ENDPOINT,omitempty" yaml:"GITLAB_ENDPOINT,omitempty"`
+	GitlabEndpoint string `default:"https://gitlab.com/" validate:"" json:"GITLAB_ENDPOINT,omitempty" yaml:"GITLAB_ENDPOINT,omitempty"`
 	ClientId       string `default:"" validate:"" json:"CLIENT_ID,omitempty" yaml:"CLIENT_ID,omitempty"`
 	ClientSecret   string `default:"" validate:"" json:"CLIENT_SECRET,omitempty" yaml:"CLIENT_SECRET,omitempty"`
 }


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1161


**Changelog:** 
- Set default Gitlab endpoint to https://gitlab.com. This ensures that a gitlab endpoint is present even when a user is not prompted for an explicit url in the ui

**Docs:** 

**Testing:** 

**Details:** 

------