### PR TITLE
Added default TESTING=false to match old Config App

### DIFF
--- a/pkg/lib/editor/js/core-config-setup/core-config-setup.js
+++ b/pkg/lib/editor/js/core-config-setup/core-config-setup.js
@@ -250,6 +250,7 @@ angular.module("quay-config")
             if($scope.validationStatus == 'success' && $scope.validationMode == 'setup'){
               $scope.config["SETUP_COMPLETE"] = true
               $scope.config["DATABASE_SECRET_KEY"] = generateDatabaseSecretKey()
+              $scope.config["TESTING"] = false
             }
           }, errorDisplay);
         };


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1202

**Changelog:** 
pkg/lib/editor/js/core-config-setup/core-config-setup.js

**Docs:** 

**Testing:** 
Starting a new idle 3.4 Quay container, connection counts should not continue to rise but stay flat (~15).

**Details:** 
Database connections for some workers not being released automatically since the config value TESTING defaults to 'true' in Quay code.  This fix overrides the default to 'false' in the config bundle to match how it works in Quay 3.3.

