### PR TITLE
Fix Kubernetes Reconfigure Endpoint (PROJQUAY-1156)

### DIFF
--- a/pkg/lib/editor/controllers.go
+++ b/pkg/lib/editor/controllers.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"path"
@@ -232,8 +231,6 @@ func commitToOperator(opts *ServerOptions) func(w http.ResponseWriter, r *http.R
 
 		for _, fieldGroup := range configBundle.ManagedFieldGroups {
 			fields := newConfig[fieldGroup].Fields()
-			// FIXME(alecmerdler): Debugging
-			fmt.Println(fields)
 			for _, field := range fields {
 				delete(configBundle.Config, field)
 			}

--- a/pkg/lib/editor/editor.go
+++ b/pkg/lib/editor/editor.go
@@ -49,7 +49,6 @@ type ConfigBundle struct {
 
 // RunConfigEditor runs the configuration editor server.
 func RunConfigEditor(password, configPath, operatorEndpoint string, readOnlyFieldGroups []string) {
-
 	// FIX THIS
 	publicKeyPath := os.Getenv("CONFIG_TOOL_PUBLIC_KEY")
 	privateKeyPath := os.Getenv("CONFIG_TOOL_PRIVATE_KEY")
@@ -146,7 +145,6 @@ func RunConfigEditor(password, configPath, operatorEndpoint string, readOnlyFiel
 
 // tlsConfig will attempt to create a tls config given a public and private key. It returns an error if it fails to create a Config.
 func loadTLS(publicKeyPath, privateKeyPath string) (*tls.Config, error) {
-
 	if publicKeyPath == "" {
 		return nil, errors.New("No public key provided for HTTPS")
 	}

--- a/pkg/lib/editor/js/core-config-setup/core-config-setup.js
+++ b/pkg/lib/editor/js/core-config-setup/core-config-setup.js
@@ -256,7 +256,7 @@ angular.module("quay-config")
         };
 
         $scope.commitToOperator = function() {
-          ApiService.commitToOperator({"config.yaml": $scope.config, "certs": $scope.certs, readOnlyFieldGroups: $scope.readOnlyFieldGroups}).then(function(resp) {
+          ApiService.commitToOperator({"config.yaml": $scope.config, "certs": $scope.certs, "managedFieldGroups": $scope.readOnlyFieldGroups}).then(function(resp) {
             alert("Successfully sent config bundle to Quay Operator")
           }, errorDisplay)
         }


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1156

**Changelog:** Fix `managedFieldGroups` not being sent to Operator reconfigure endpoint.

**Docs:** N/a

**Testing:** N/a

**Details:** Fixes TNG Operator reconfigure JSON payload.