### PR TITLE
Removed port is cert hostname validation

### DIFF
--- a/pkg/lib/shared/validators.go
+++ b/pkg/lib/shared/validators.go
@@ -370,7 +370,13 @@ func ValidateCertPairWithHostname(cert, key []byte, hostname string, fgName stri
 
 	certificate, err := x509.ParseCertificate(certChain.Certificate[0])
 
-	err = certificate.VerifyHostname(hostname)
+	// Make sure port is removed
+	cleanHost, _, err := net.SplitHostPort(hostname)
+	if err != nil {
+		cleanHost = hostname
+	}
+
+	err = certificate.VerifyHostname(cleanHost)
 	if err != nil {
 		newError := ValidationError{
 			Tags:       []string{"Certificates"},


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1324

**Changelog:** 

- Config-tool will check if a port is appended to a hostname and remove it before validating that name against an SSL certificate. 

**Docs:** 

**Testing:** 

**Details:** 

------