### PR TITLE
Fixed modals

### DIFF
--- a/pkg/lib/editor/controllers.go
+++ b/pkg/lib/editor/controllers.go
@@ -265,10 +265,16 @@ func commitToOperator(opts *ServerOptions) func(w http.ResponseWriter, r *http.R
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-
 		defer resp.Body.Close()
 
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(resp.StatusCode)
 		w.Header().Add("Content-Type", "application/json")
-		w.Write(js)
+		w.Write(body)
 	}
 }

--- a/pkg/lib/editor/js/components/file-upload-box.html
+++ b/pkg/lib/editor/js/components/file-upload-box.html
@@ -13,6 +13,9 @@
                 and {{ selectedFiles.length - 1 }} others...
               </span>
             </span>
+          </span><span class="choose-button">
+            <span>Select file</span>
+          </span>
         </label>
       </form>
     </div>

--- a/pkg/lib/editor/js/components/file-upload-box.js
+++ b/pkg/lib/editor/js/components/file-upload-box.js
@@ -56,6 +56,9 @@ angular.module('quay-config').directive('fileUploadBox', function () {
             conductUpload(selectedFiles[i])
           }
         }
+
+        $scope.state = "clear"
+        $scope.selectedFiles = []
       };
 
 
@@ -76,12 +79,15 @@ angular.module('quay-config').directive('fileUploadBox', function () {
           $scope.$apply(function(){
             $scope.certs["extra_ca_certs/"+file.name] = btoa(e.target.result)
             $scope.uploadProgress = 100
-            $scope.state = 'okay'
+            $scope.state = 'clear'
           })
         }
 
         reader.onerror = function(e){
-          $scope.$apply(function() { doneCb(false, 'Error when uploading'); });
+          $scope.$apply(function () {
+            doneCb(false, 'Error when uploading');
+            $scope.state = "clear";
+          });
         }
 
       };

--- a/pkg/lib/editor/js/config-field-templates/config-certificates-field.html
+++ b/pkg/lib/editor/js/config-field-templates/config-certificates-field.html
@@ -41,7 +41,7 @@
             <td class="cert-status">
               <div ng-if="certificate.error" class="red">
                 <i class="fa fa-exclamation-circle"></i>
-                Error: {{ certificate.error }}
+                {{ certificate.error }}
               </div>
               <div ng-if="certificate.expired" class="orange">
                 <i class="fa fa-exclamation-triangle"></i>
@@ -55,6 +55,13 @@
             <td>
               <div class="empty" ng-if="!certificate.names">(None)</div>
               <a class="dns-name" ng-href="http://{{ name }}" ng-repeat="name in certificate.names" ng-safenewtab>{{ name }}</a>
+            </td>
+            <td class="options-col">
+              <span class="cor-options-menu">
+                <span class="cor-option" option-click="deleteCert(certificate.path)">
+                  <i class="fa fa-times"></i> Delete Certificate
+                </span>
+              </span>
             </td>
           </tr>
         </table>

--- a/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
+++ b/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
@@ -5,9 +5,18 @@
       <span class="cor-title-content">Red Hat Quay Setup</span>
     </div>
     <div class="co-main-content-panel" style="padding: 20px;">
-<div class="config-setup-tool-element">
-  <div class="cor-loader" ng-if="!config"></div>
-  <div ng-show="true">
+      <div class="co-alert co-alert-warning" ng-if="validationMode=='setup'">
+        <div></div>
+        <div>
+          <strong>You are in a setup session!</strong>
+        </div>
+        <div>
+          No configuration bundle was mounted: default values will be used.
+        </div>
+      </div>
+    <div class="config-setup-tool-element">
+    <div class="cor-loader" ng-if="!config"></div>
+    <div ng-show="true">
     <form id="configform" name="configform">
       <!-- Custom SSL certificates -->
       <div class="co-panel" id="custom-ssl">
@@ -1967,15 +1976,49 @@
             </h4>
           </div>
           <div class="modal-body">
-            <span class="quay-spinner" ng-show="validationStatus == 'validating'"></span>
-            <div class="validation-success-container" ng-if="validationStatus == 'success'">
-              <i class="fa fa-lg fa-check-circle" ng-show="validationStatus == 'success'"></i>
-              No problems occurred
-            </div>
-            <div class="validation-issue-container" ng-if="validationStatus == 'error'">
-              <div class="validation-issue" ng-repeat="err in validationResult">
-                <i class="fa fa-lg fa-warning"></i>
-                {{ err['FieldGroup'] }}:{{ err['Message'] }}
+            <div class="service-verification">
+
+              <!-- Validating Config -->
+              <div class="service-verification-row" ng-if="validationStatus == 'validating'">
+                <span class="cor-loader-inline" ng-show="validationStatus == 'validating'"></span>
+                  <span class="service-title">Validating Configuration</span>
+              </div>
+
+
+              <!-- Successful Validation -->
+              <div class="service-verification-row" ng-if="validationStatus == 'success'">
+                <i class="fa fa-lg fa-check-circle" ng-show="validationStatus == 'success'"></i>
+                <span class="service-title">Configuration Validated</span>
+              </div>
+
+              <!-- Error in Validations-->
+              <div ng-if="validationStatus == 'error'">
+                <div class="service-verification-row" ng-repeat="err in validationResult">
+                  <i class="fa fa-lg fa-warning"></i>
+                  <span class="service-title">{{ err['FieldGroup'] }}</span>
+                  <div class="service-verification-error" ng-repeat="msg in err.Message track by $index"">
+                    {{ msg }}
+                  </div>
+                </div>
+              </div>
+
+              <!-- Committing to Operator -->
+              <div class="service-verification-row" ng-if="operatorCommitStatus == 'inProgress'">
+                <span class="cor-loader-inline" ng-show="operatorCommitStatus == 'inProgress'"></span>
+                <span class="service-title">Committing to Operator</span>
+              </div>
+              
+              
+              <!-- Successful commit to operator -->
+              <div class="service-verification-row" ng-if="operatorCommitStatus == 'success'">
+                <i class="fa fa-lg fa-check-circle" ng-show="operatorCommitStatus == 'success'"></i>
+                <span class="service-title">Config Sent to Operator</span>
+              </div>
+              
+              <!-- Error in Commit-->
+              <div class="service-verification-row" ng-if="operatorCommitStatus == 'error'">
+                <i class="fa fa-lg fa-warning" ng-show="operatorCommitStatus == 'error'"></i>
+                <span class="service-title">Could not reconfigure Quay</span>
               </div>
             </div>
           </div>
@@ -2028,7 +2071,7 @@
       </div><!-- /.modal-dialog -->
     </div><!-- /.modal -->
 
-  </div>
+    </div>
   </div>
 </div>
 </div>

--- a/pkg/lib/editor/static/css/core-ui.css
+++ b/pkg/lib/editor/static/css/core-ui.css
@@ -567,15 +567,18 @@ a:focus {
   color: rgb(53, 186, 53);
 }
 
-.config-setup-tool .validation-issue-container {
-  margin-bottom: 10px;
-  max-height: 250px;
-  overflow: auto;
-  border: 1px solid #797979;
-  background: black;
-  padding: 6px;
-  font-family: Consolas, "Lucida Console", Monaco, monospace;
-  font-size: 12px;
+
+.config-setup-tool .service-verification-error {
+    margin-top: 10px;
+    margin-left: 36px;
+    margin-bottom: 20px;
+    max-height: 250px;
+    overflow: auto;
+    border: 1px solid #797979;
+    background: #000;
+    padding: 6px;
+    font-family: Consolas,Lucida Console,Monaco,monospace;
+    font-size: 12px;
 }
 
 .config-setup-tool .validation-issue {

--- a/pkg/lib/editor/static/css/quay.css
+++ b/pkg/lib/editor/static/css/quay.css
@@ -3953,6 +3953,63 @@ i.mesos-icon {
     background-color: #CC0000;
 }
 
+.file-upload-box-element .file-drop + label .choose-button {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    cursor: pointer;
+    display: inline-block;
+    overflow: hidden;
+    padding: 8px;
+    color: #fff;
+    font-weight: 400;
+    font-size: 16px;
+    height: 34px;
+    vertical-align: top;
+    padding-left: 16px;
+    padding-right: 16px;
+    line-height: 18px;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+}
+
+.file-upload-box-element .file-drop {
+    width: .1px;
+    height: .1px;
+    opacity: 0;
+    overflow: hidden;
+    position: absolute;
+    z-index: -1;
+}
+
+.file-upload-box-element .select-message {
+    color: #888;
+}
+
+.file-upload-box-element .file-drop + label {
+    cursor: pointer;
+}
+
+.file-upload-box-element .file-drop + label .chosen-file {
+    background: #fff;
+    display: inline-block;
+    height: 34px;
+    line-height: 34px;
+    padding-left: 10px;
+    padding-right: 10px;
+    font-weight: 400;
+    width: 250px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+        border-top-right-radius: 4px;
+        border-bottom-right-radius: 4px;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.file-upload-box-element .file-drop + label * {
+    pointer-events: none;
+}
+
 .onprem .co-nav-title .co-nav-title-action a {
   color: black;
 }


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-???

**Changelog:** 
- **Fixed CSS on modals for validation errors**

![validation_pass](https://user-images.githubusercontent.com/12652049/100660087-86975700-331f-11eb-814f-d9f27aaef2c6.png)

![validation_failed](https://user-images.githubusercontent.com/12652049/100660074-839c6680-331f-11eb-84e0-a50349d1a61f.png)

- **Added proper modal for Quay reconfigure endpoint**

![cannot_reconfigure](https://user-images.githubusercontent.com/12652049/100660241-ba727c80-331f-11eb-8faa-92e3ecce607e.png)

- **Fixed upload certificate box. Bad certs will be uploaded and the error message will be shown under 'status'. The user can also now delete certificates that they have uploaded.**

![customSSL](https://user-images.githubusercontent.com/12652049/100659355-85b1f580-331e-11eb-9591-9d552c19c317.png)


- **Removed alert and replaced with below modal when a user loads config-app without a config bundle. This sets up a setup session with defaults**

![setupmode](https://user-images.githubusercontent.com/12652049/100659662-ec371380-331e-11eb-9ecf-ac6f1bc3332f.png)


**Docs:** 

**Testing:** 

**Details:** 

------
