### PR TITLE
validation tested and working on swift authv3

### DIFF
--- a/commands/validate.go
+++ b/commands/validate.go
@@ -60,7 +60,7 @@ var validateCmd = &cobra.Command{
 		// Load into struct
 		configFieldGroups, err := config.NewConfig(conf)
 		if err != nil {
-			fmt.Println(err.Error())
+			fmt.Println("An error occurred during validation. Process could not marshal config.yaml. This is most likely due to an incorrect type. \nMore info: " + err.Error())
 			return
 		}
 


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1307

**Changelog:** 

- Config tool will now validate Swift storage v3 auth. It will also ensure that the listed container is in fact present.
- Added clearer error message in `validate` command CLI output when type errors are found during `config.yaml` unmarshalling

**Docs:** 

**Testing:** 

**Details:** 

------