### PR TITLE
Fix CloudFront Validation (PROJQUAY-1306)

### DIFF
--- a/pkg/lib/editor/js/core-config-setup/core-config-setup.js
+++ b/pkg/lib/editor/js/core-config-setup/core-config-setup.js
@@ -1073,7 +1073,6 @@ angular.module("quay-config")
         };
 
         var conductUpload = function(file) {
- 
           var reader = new FileReader();
           reader.readAsText(file);
 
@@ -1091,6 +1090,7 @@ angular.module("quay-config")
                 $scope.certs[$scope.filename] = btoa(e.target.result);
                 $scope.hasFile = true;
                 $scope.uploadProgress = null;
+                $scope.binding = $scope.filename;
               } catch (err) {
                 $scope.hasFile = false;
                 $scope.uploadProgress = null;


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1306

**Changelog:** Fix CloudFront storage validation.

**Docs:** N/a

**Testing:** N/a

**Details:** The validation logic for CloudFront S3 storage was incorrectly using the public key ID (`cloudfront_key_id`) as the distribution ID when looking up the CloudFront distribution. As the distribution ID is not a field in `config.yaml`, instead change the logic to list distributions and search for one which matches the provided `cloudfront_distribution_domain`. Also check that there is a public key for the given `cloudfront_key_id`.