### PR TITLE
fixed error message for default tag expiration options

### DIFF
--- a/pkg/lib/fieldgroups/timemachine/timemachine_validator.go
+++ b/pkg/lib/fieldgroups/timemachine/timemachine_validator.go
@@ -11,6 +11,7 @@ func (fg *TimeMachineFieldGroup) Validate(opts shared.Options) []shared.Validati
 	errors := []shared.ValidationError{}
 
 	if ok, err := shared.ValidateIsOneOfString(fg.DefaultTagExpiration, shared.InterfaceArrayToStringArray(fg.TagExpirationOptions), "DEFAULT_TAG_EXPIRATION", fgName); !ok {
+		err.Message = "The default tag expiration period must be included in the allowed expiration periods."
 		errors = append(errors, err)
 		return errors
 	}

--- a/pkg/lib/shared/validators.go
+++ b/pkg/lib/shared/validators.go
@@ -175,7 +175,7 @@ func ValidateIsOneOfString(input string, options []string, field string, fgName 
 		newError := ValidationError{
 			Tags:       []string{field},
 			FieldGroup: fgName,
-			Message:    field + " must be one of " + strings.Join(options, ",") + ".",
+			Message:    field + " must be one of " + strings.Join(options, ", ") + ".",
 		}
 		return false, newError
 	}


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1262

**Changelog:** 
- Updated error message for default tag expiration option not being contained as one of the allowed expiration options.

**Docs:** 

**Testing:** 

**Details:** 

------