### PR TITLE
[WIP] Fix Postgres TLS Validation

### DIFF
--- a/pkg/lib/fieldgroups/database/database_test.go
+++ b/pkg/lib/fieldgroups/database/database_test.go
@@ -40,6 +40,8 @@ func TestValidateDatabase(t *testing.T) {
 
 			opts := shared.Options{
 				Mode: "testing",
+				// FIXME(alecmerdler): Test TLS
+				Certificates: nil,
 			}
 
 			validationErrors := fg.Validate(opts)

--- a/pkg/lib/fieldgroups/database/database_validator.go
+++ b/pkg/lib/fieldgroups/database/database_validator.go
@@ -108,6 +108,7 @@ func ValidateDatabaseConnection(opts shared.Options, uri *url.URL, caCert string
 				return errors.New("Could not add CA cert to pool")
 			}
 			tlsConfig := &tls.Config{
+				ServerName:         strings.Split(fullHostName, ":")[0],
 				InsecureSkipVerify: false,
 				RootCAs:            caCertPool,
 			}
@@ -136,7 +137,7 @@ func ValidateDatabaseConnection(opts shared.Options, uri *url.URL, caCert string
 	} else if scheme == "postgresql" {
 
 		// If there is no port, add 5432 as default
-		_, _, err := net.SplitHostPort(fullHostName)
+		host, _, err := net.SplitHostPort(fullHostName)
 		if err != nil {
 			fullHostName = fullHostName + ":5432"
 		}
@@ -160,6 +161,7 @@ func ValidateDatabaseConnection(opts shared.Options, uri *url.URL, caCert string
 				return errors.New("Could not add CA cert to pool")
 			}
 			tlsConfig := &tls.Config{
+				ServerName:         host,
 				InsecureSkipVerify: false,
 				RootCAs:            caCertPool,
 			}


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1270

**Changelog:** Fix Postgres TLS validation to include `ServerName`.

**Docs:** N/a

**Testing:** N/a

**Details:** The TLS config was missing the `ServerName` field when attempting to validate using the config editor.
