### PR TITLE
PROJQUAY-1561

### DIFF
--- a/pkg/lib/editor/js/core-config-setup/core-config-setup.js
+++ b/pkg/lib/editor/js/core-config-setup/core-config-setup.js
@@ -292,7 +292,7 @@ angular.module("quay-config")
 
           if($scope.certs["database.pem"]){
             $scope.config["DB_CONNECTION_ARGS"]["ssl"] = {}
-            $scope.config["DB_CONNECTION_ARGS"]["ssl"]["ca"] = "database.pem";
+            $scope.config["DB_CONNECTION_ARGS"]["ssl"]["ca"] = "/conf/stack/database.pem";
           }
 
           var errorDisplay = ApiService.errorDisplay(


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1561

**Changelog:** 
- Config editor sets `ca` field to `/conf/stack/database.pem` when uploading a cert for mysql/postgres

**Docs:** 

**Testing:** 

**Details:** 

------