### PR TITLE
Keep `HostSettings` Fieldgroup Intact during Operator Reconfigure

### DIFF
--- a/pkg/lib/editor/controllers.go
+++ b/pkg/lib/editor/controllers.go
@@ -233,6 +233,11 @@ func commitToOperator(opts *ServerOptions) func(w http.ResponseWriter, r *http.R
 		}
 
 		for _, fieldGroup := range configBundle.ManagedFieldGroups {
+			// NOTE: Skip `HostSettings` because it is a special case where we allow setting the fields.
+			if fieldGroup == "HostSettings" {
+				continue
+			}
+
 			fields := newConfig[fieldGroup].Fields()
 			for _, field := range fields {
 				delete(configBundle.Config, field)


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1577

**Changelog:** Do not strip out `HostSettings` fieldgroup when submitting to Operator.

**Docs:** N/a

**Testing:** Use config editor to reconfigure with Operator and ensure that `SERVER_HOSTNAME` is unchanged.

**Details:** The `HostSettings` field group is unique because it can be marked as managed, but we allow users to set the `SERVER_HOSTNAME` and provide their own TLS cert/key pair. 