### PR TITLE
Use swift region_name parameter if provided in config validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/lib/pq v1.7.0
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/minio/minio-go/v7 v7.0.5
-	github.com/ncw/swift v1.0.52
+	github.com/ncw/swift/v2 v2.0.0
 	github.com/olekukonko/tablewriter v0.0.5-0.20200416053754-163badb3bac6
 	github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e // indirect
 	github.com/spf13/cobra v1.0.0

--- a/pkg/lib/shared/storage_validators.go
+++ b/pkg/lib/shared/storage_validators.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
-	"github.com/ncw/swift"
+	"github.com/ncw/swift/v2"
 )
 
 // ValidateStorage will validate a S3 storage connection.
@@ -439,6 +439,7 @@ func validateAzureGateway(opts Options, storageName, accountName, accountKey, co
 func validateSwift(opts Options, storageName string, authVersion int, swiftUser, swiftPassword, containerName, authUrl string, osOptions map[string]interface{}, fgName string) (bool, ValidationError) {
 
 	var c swift.Connection
+	ctx := context.Background()
 	switch authVersion {
 	case 1:
 		c = swift.Connection{
@@ -484,7 +485,7 @@ func validateSwift(opts Options, storageName string, authVersion int, swiftUser,
 		}
 	}
 
-	err := c.Authenticate()
+	err := c.Authenticate(ctx)
 	if err != nil {
 		return false, ValidationError{
 			FieldGroup: fgName,
@@ -494,7 +495,7 @@ func validateSwift(opts Options, storageName string, authVersion int, swiftUser,
 	}
 
 	// List containers
-	containers, err := c.ContainerNames(nil)
+	containers, err := c.ContainerNames(ctx, nil)
 	if err != nil {
 		return false, ValidationError{
 			FieldGroup: fgName,

--- a/pkg/lib/shared/storage_validators.go
+++ b/pkg/lib/shared/storage_validators.go
@@ -440,6 +440,12 @@ func validateSwift(opts Options, storageName string, authVersion int, swiftUser,
 
 	var c swift.Connection
 	ctx := context.Background()
+	var region string
+	var ok bool
+	if region, ok = osOptions["region_name"].(string); ok {
+		region = osOptions["region_name"].(string)
+	}
+
 	switch authVersion {
 	case 1:
 		c = swift.Connection{
@@ -454,6 +460,7 @@ func validateSwift(opts Options, storageName string, authVersion int, swiftUser,
 			ApiKey:      swiftPassword,
 			AuthUrl:     authUrl,
 			AuthVersion: 2,
+			Region:      region,
 		}
 	case 3:
 
@@ -482,6 +489,7 @@ func validateSwift(opts Options, storageName string, authVersion int, swiftUser,
 			AuthVersion: 3,
 			Domain:      domain,
 			TenantId:    tenantId,
+			Region:      region,
 		}
 	}
 


### PR DESCRIPTION
- Update ncw/swift to version 2 (add context parameter in most API calls)
- Use swift region_name when provided, otherwise, config validation may fail if your container lives in a different region than the default one.
