### PR TITLE
frontend: Set default USERFILES_LOCATION to a valid storage

### DIFF
--- a/pkg/lib/editor/js/core-config-setup/core-config-setup.js
+++ b/pkg/lib/editor/js/core-config-setup/core-config-setup.js
@@ -269,7 +269,7 @@ angular.module("quay-config")
           config["BITTORRENT_FILENAME_PEPPER"] = generateDatabaseSecretKey();
           config["FEATURE_ACI_CONVERSION"] = false;
           config["USE_CDN"] = false;
-          config["USERFILES_LOCATION"] = "default";
+          config["USERFILES_LOCATION"] = config["DISTRIBUTED_STORAGE_PREFERENCE"][0] || Object.keys(config["DISTRIBUTED_STORAGE_CONFIG"])[0] || "default";
           config["TESTING"] = false;
           if (!("FEATURE_REQUIRE_TEAM_INVITE" in config)) {
             config["FEATURE_REQUIRE_TEAM_INVITE"] = true;


### PR DESCRIPTION
Make sure USERFILES_LOCATION is set to an existing storage instead of
always using "default".

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1742

**Changelog:** 
- Make sure USERFILES_LOCATION is set to an existing storage instead of
always using "default".

**Docs:** 

**Testing:** 

**Details:** 
