### PR TITLE
OIDC Validation Client Context

### DIFF
--- a/pkg/lib/fieldgroups/oidc/oidc_validator.go
+++ b/pkg/lib/fieldgroups/oidc/oidc_validator.go
@@ -65,9 +65,7 @@ func (fg *OIDCFieldGroup) Validate(opts shared.Options) []shared.ValidationError
 		tr := &http.Transport{TLSClientConfig: config}
 		client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
 
-		// Create http client context
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
+		ctx := goOIDC.ClientContext(context.Background(), client)
 
 		if !strings.HasSuffix(provider.OIDCServer, "/") {
 			newError := shared.ValidationError{


### PR DESCRIPTION
Use the custom client context to ensure self-signed certificates can be used when validating OIDC providers.