### PR TITLE
Ensure mail tls is enabled when running in fips mode

### DIFF
--- a/pkg/lib/fieldgroups/email/email.go
+++ b/pkg/lib/fieldgroups/email/email.go
@@ -18,6 +18,7 @@ type EmailFieldGroup struct {
 	MailUseAuth              bool          `default:"false" validate:"" yaml:"MAIL_USE_AUTH" json:"MAIL_USE_AUTH"`
 	MailUsername             string        `default:"" validate:"" yaml:"MAIL_USERNAME,omitempty" json:"MAIL_USERNAME,omitempty"`
 	MailUseTls               bool          `default:"false" validate:"" yaml:"MAIL_USE_TLS" json:"MAIL_USE_TLS"`
+	FeatureFIPS              bool          `default:"false" validate:"" yaml:"FEATURE_FIPS" json:"FEATURE_FIPS"`
 }
 
 // NewEmailFieldGroup creates a new EmailFieldGroup

--- a/pkg/lib/fieldgroups/email/email_validator.go
+++ b/pkg/lib/fieldgroups/email/email_validator.go
@@ -77,6 +77,17 @@ func (fg *EmailFieldGroup) Validate(opts shared.Options) []shared.ValidationErro
 		}
 	}
 
+	// If FIPS is enabled, ensure mail tls is enabled
+	if fg.FeatureFIPS && !fg.MailUseTls {
+		newError := shared.ValidationError{
+			Tags:       []string{"MAIL_USE_TLS", "FEATURE_FIPS"},
+			FieldGroup: fgName,
+			Message:    "MAIL_USE_TLS must be enabled when running in FIPS mode.",
+		}
+		errors = append(errors, newError)
+		return errors
+	}
+
 	// If auth is enabled, try to authenticate
 	if fg.MailUseAuth {
 		auth := smtp.PlainAuth("", fg.MailUsername, fg.MailPassword, fg.MailServer)


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1804

**Changelog:** 
- Add validation check for `MAIL_USE_TLS` enabled when `FEATURE_FIPS` is enabled
**Docs:** 

**Testing:** 

**Details:** 

------