### PR TITLE
securityscanner: validate introspection endpoint (PROJQUAY-1610)

### DIFF
--- a/pkg/lib/fieldgroups/securityscanner/securityscanner_validator.go
+++ b/pkg/lib/fieldgroups/securityscanner/securityscanner_validator.go
@@ -1,8 +1,12 @@
 package securityscanner
 
 import (
+	"net/url"
+
 	"github.com/quay/config-tool/pkg/lib/shared"
 )
+
+const introspectionPort = "8089"
 
 // Validate checks the configuration settings for this field group
 func (fg *SecurityScannerFieldGroup) Validate(opts shared.Options) []shared.ValidationError {
@@ -55,7 +59,11 @@ func (fg *SecurityScannerFieldGroup) Validate(opts shared.Options) []shared.Vali
 
 		// Check that endpoint is reachable
 		if opts.Mode == "online" {
-			if ok, err := shared.ValidateHostIsReachable(opts, fg.SecurityScannerV4Endpoint, "SECURITY_SCANNER_V4_ENDPOINT", "SecurityScanner"); !ok {
+			// NOTE: We validate against the introspection endpoint, because the main endpoint will refuse connections until fully initialized.
+			endpoint, _ := url.Parse(fg.SecurityScannerV4Endpoint)
+			introspectionEndpoint := endpoint.Hostname() + ":" + introspectionPort
+
+			if ok, err := shared.ValidateHostIsReachable(opts, introspectionEndpoint, "SECURITY_SCANNER_V4_ENDPOINT", "SecurityScanner"); !ok {
 				errors = append(errors, err)
 			}
 		}


### PR DESCRIPTION
Clair v4 will refuse connections to the main app port until the
vulnerability database is fully initialized. This should not block
Quay's validation, so we point to Clair's introspection server to
validate instead (which accepts connections during init).
    
Signed-off-by: Alec Merdler <alecmerdler@gmail.com>