### PR TITLE
PROJQUAY-2149: Add SSL to build log and user event Redis config

### DIFF
--- a/pkg/lib/fieldgroups/redis/redis.go
+++ b/pkg/lib/fieldgroups/redis/redis.go
@@ -17,6 +17,7 @@ type UserEventsRedisStruct struct {
 	Password string `default:"" validate:"" json:"password,omitempty" yaml:"password,omitempty"`
 	Port     int    `default:"" validate:"" json:"port,omitempty" yaml:"port,omitempty"`
 	Host     string `default:"" validate:"" json:"host,omitempty" yaml:"host,omitempty"`
+	Ssl      bool   `default:"false" validate:"" json:"ssl,omitempty" yaml:"ssl,omitempty"`
 }
 
 // BuildlogsRedisStruct represents the BuildlogsRedisStruct config fields
@@ -24,6 +25,7 @@ type BuildlogsRedisStruct struct {
 	Password string `default:"" validate:"" json:"password,omitempty" yaml:"password,omitempty"`
 	Port     int    `default:"" validate:"" json:"port,omitempty" yaml:"port,omitempty"`
 	Host     string `default:"" validate:"" json:"host,omitempty" yaml:"host,omitempty"`
+	Ssl      bool   `default:"false" validate:"" json:"ssl,omitempty" yaml:"ssl,omitempty"`
 }
 
 // NewRedisFieldGroup creates a new RedisFieldGroup

--- a/pkg/lib/fieldgroups/redis/redis_validator.go
+++ b/pkg/lib/fieldgroups/redis/redis_validator.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"crypto/tls"
 	"fmt"
 
 	"github.com/go-redis/redis/v8"
@@ -41,10 +42,18 @@ func (fg *RedisFieldGroup) Validate(opts shared.Options) []shared.ValidationErro
 		addr = addr + ":" + fmt.Sprintf("%d", fg.BuildlogsRedis.Port)
 	}
 
+	var tlsConfig *tls.Config = nil
+	if fg.BuildlogsRedis.Ssl {
+		tlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+
 	options := &redis.Options{
 		Addr:     addr,
 		Password: fg.BuildlogsRedis.Password,
 		DB:       0,
+		TLSConfig: tlsConfig,
 	}
 	if ok, err := shared.ValidateRedisConnection(options, "BUILDLOGS_REDIS", "Redis"); !ok {
 		errors = append(errors, err)
@@ -55,10 +64,19 @@ func (fg *RedisFieldGroup) Validate(opts shared.Options) []shared.ValidationErro
 	if fg.UserEventsRedis.Port != 0 {
 		addr = addr + ":" + fmt.Sprintf("%d", fg.BuildlogsRedis.Port)
 	}
+
+	tlsConfig = nil
+	if fg.UserEventsRedis.Ssl {
+		tlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+
 	options = &redis.Options{
 		Addr:     addr,
 		Password: fg.UserEventsRedis.Password,
 		DB:       0,
+		TLSConfig: tlsConfig,
 	}
 	if ok, err := shared.ValidateRedisConnection(options, "USER_EVENTS_REDIS", "Redis"); !ok {
 		errors = append(errors, err)


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-2149

**Changelog:** 

Adding support for SSL in the redis config validator