### PR TITLE
Normalize 'notAfter' string returned by x509 library

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,8 @@
-# Root of this project (aka parent dir of this file)
-CT_DIR=/home/jonathan/Desktop/config-tool
-
 # Path to config bundle directory (uses testdata by defaut, you can change this to any path to a config bundle)
-CONFIG_MOUNT=${CT_DIR}/testdata/config-bundle
+CONFIG_MOUNT=${PWD}/testdata/config-bundle-private
 
 # TLS Config
-CT_PUBLIC_KEY=${CT_DIR}/testdata/tls/localhost.crt
-CT_PRIVATE_KEY=${CT_DIR}/testdata/tls/localhost.key
+CT_PUBLIC_KEY=${PWD}/testdata/tls/localhost.crt
+CT_PRIVATE_KEY=${PWD}/testdata/tls/localhost.key
 
 # OPERATOR_ENDPOINT=https://webhook.site/82875d14-4712-42d0-af6a-4ff451c92410

--- a/pkg/lib/editor/js/core-config-setup/core-config-setup.js
+++ b/pkg/lib/editor/js/core-config-setup/core-config-setup.js
@@ -1508,7 +1508,13 @@ angular.module("quay-config")
                   const c = new X509();
                   c.readCertPEM(atob(contents));
                   const current = new Date();
-                  const expired = current > new Date(c.getNotAfter());
+                  // This function returns a bad string, so we have to do some extra formatting to normalize it. 
+                  let originalDateString = "20"+c.getNotAfter()
+                  let formattedDateString = originalDateString.replace(
+                    /(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/,
+                    "$1-$2-$3T$4:$5:$6"
+                  );
+                  const expired = current > Date.parse(formattedDateString);
                   let names = c
                     .getSubjectString()
                     .split("/")

--- a/pkg/lib/fieldgroups/database/database.go
+++ b/pkg/lib/fieldgroups/database/database.go
@@ -77,6 +77,18 @@ func NewDbConnectionArgsStruct(fullConfig map[string]interface{}) (*DbConnection
 			return newDbConnectionArgsStruct, errors.New("autorollback must be of type bool")
 		}
 	}
+	if value, ok := fullConfig["sslmode"]; ok {
+		newDbConnectionArgsStruct.SslMode, ok = value.(string)
+		if !ok {
+			return newDbConnectionArgsStruct, errors.New("sslmode must be of type string")
+		}
+	}
+	if value, ok := fullConfig["sslrootcert"]; ok {
+		newDbConnectionArgsStruct.SslRootCert, ok = value.(string)
+		if !ok {
+			return newDbConnectionArgsStruct, errors.New("sslrootcert must be of type string")
+		}
+	}
 
 	return newDbConnectionArgsStruct, nil
 }


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1815

**Changelog:** 
- Added regex to normalized date string returned by x509 library. This ensures that the expiration date is parsed correctly.
- Replaced hard coded CT_DIR variable to $PWD

**Docs:** 

**Testing:** 

**Details:** 

------
