### PR TITLE
editor: Add sslmode=verify-full when Postgres cert uploaded (PROJQUAY-2200)

### DIFF
--- a/pkg/lib/editor/js/core-config-setup/core-config-setup.js
+++ b/pkg/lib/editor/js/core-config-setup/core-config-setup.js
@@ -295,9 +295,11 @@ angular.module("quay-config")
           if($scope.certs["database.pem"] && $scope.config["DB_URI"].startsWith("postgres")){
             delete $scope.config["DB_CONNECTION_ARGS"]["ssl"];
             $scope.config["DB_CONNECTION_ARGS"]["sslrootcert"] = "conf/stack/database.pem";
+            $scope.config["DB_CONNECTION_ARGS"]["sslmode"] = "verify-full"
           } else if 
             ($scope.certs["database.pem"] && $scope.config["DB_URI"].startsWith("mysql")){
-            delete $scope.config["DB_CONNECTION_ARGS"]["sslrootcert"];  
+            delete $scope.config["DB_CONNECTION_ARGS"]["sslrootcert"];
+            delete $scope.config["DB_CONNECTION_ARGS"]["sslmode"];    
             $scope.config["DB_CONNECTION_ARGS"]["ssl"] = {}
             $scope.config["DB_CONNECTION_ARGS"]["ssl"]["ca"] = "conf/stack/database.pem";
           }


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-2200

**Changelog:** 
- Add 'sslmode=verify-full' to DB_CONNECTION_ARGS when Postgres cert is uploaded from the config editor

**Docs:** 

**Testing:** 

**Details:** 

------