### PR TITLE
href: Fix broken link (PROJQUAY-2449)

### DIFF
--- a/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
+++ b/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
@@ -1894,7 +1894,7 @@
             <p>
               <strong>Note:</strong> A registered GitLab OAuth application is required.
               Visit the
-              <a target="_blank" rel="noopener noreferrer" href="{{ config.GITLAB_TRIGGER_CONFIG.GITLAB_ENDPOINT || 'https://gitlab.com' }}/profile/applications"
+              <a target="_blank" rel="noopener noreferrer" href="{{ config.GITLAB_TRIGGER_CONFIG.GITLAB_ENDPOINT || 'https://gitlab.com' }}/~/profile/applications"
                  ng-safenewtab>
                 GitLab applications admin panel
               </a>


### PR DESCRIPTION
The link to creating a new application in gitlab
was fixed

Signed-off-by: harishsurf <hgovinda@redhat.com>

**Issue:** https://issues.redhat.com/browse/PROJQUAY-2449