### PR TITLE
WIP - tls: setting EXTERNAL_TLS_TERMINATION to false (PROJQUAY-2428)

### DIFF
--- a/pkg/lib/editor/js/core-config-setup/core-config-setup.js
+++ b/pkg/lib/editor/js/core-config-setup/core-config-setup.js
@@ -614,7 +614,7 @@ angular.module("quay-config")
 
             case 'internal-tls':
               $scope.config['PREFERRED_URL_SCHEME'] = 'https';
-              delete $scope.config['EXTERNAL_TLS_TERMINATION'];
+              $scope.config['EXTERNAL_TLS_TERMINATION'] = false;
               return;
           }
         };


### PR DESCRIPTION
If the TLS termination is not executed at the load balancer level we
need to set this configuration to 'false' instead of simply deleting.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-2428