### PR TITLE
tlscomponent: changing option message for custom tls (PROJQUAY-2428)

### DIFF
--- a/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
+++ b/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
@@ -112,7 +112,7 @@
               <td>TLS:</td>
               <td>
                 <select ng-disabled="fieldGroupReadonly('HostSettings')" class="form-control" ng-model="mapped.TLS_SETTING">
-                  <option value="internal-tls">Red Hat Quay handles TLS</option>
+                  <option value="internal-tls">Custom certificates</option>
                   <option value="external-tls">My own load balancer handles TLS (Not Recommended)</option>
                   <option value="none">None (Not For Production)</option>
                 </select>


### PR DESCRIPTION
To better reflect the option this commit changes the option presented to
the user. Instead of informing users that Quay pod would be responsible
for terminating the TLS we now inform users that they can provide custom
TLS certificates.

We still do the TLS termination at the load balancer level but this time
using user provided certificates.