### PR TITLE
configvalidation: load only certificates (PROJQUAY-2416)

### DIFF
--- a/pkg/lib/shared/functions.go
+++ b/pkg/lib/shared/functions.go
@@ -59,7 +59,7 @@ func LoadCerts(dir string) map[string][]byte {
 	// Get filenames in directory
 	certs := make(map[string][]byte)
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() || strings.Contains(path, "..") || (!strings.HasSuffix(path, ".crt") && !strings.HasSuffix(path, ".cert") && !strings.HasSuffix(path, ".key") && !strings.HasSuffix(path, ".pem")) {
+		if info.IsDir() || strings.Contains(path, "..") || (!strings.HasSuffix(path, ".crt") && !strings.HasSuffix(path, ".cert") && !strings.HasSuffix(path, ".pem")) {
 			return nil
 		}
 


### PR DESCRIPTION
Avoid attempting to load private keys. By loading private keys
AppendCertsFromPEM() fails, it only accepts CERTIFICATES.