### PR TITLE
validation: ignore err in LoadCerts

### DIFF
--- a/pkg/lib/shared/functions.go
+++ b/pkg/lib/shared/functions.go
@@ -59,13 +59,18 @@ func LoadCerts(dir string) map[string][]byte {
 	// Get filenames in directory
 	certs := make(map[string][]byte)
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if info.IsDir() || strings.Contains(path, "..") || (!strings.HasSuffix(path, ".crt") && !strings.HasSuffix(path, ".cert") && !strings.HasSuffix(path, ".pem")) {
 			return nil
 		}
 
 		data, err := ioutil.ReadFile(path)
 		if err != nil {
-			return err
+			// It's possible different, unreadable files are here.
+			return nil
 		}
 
 		relativePath, err := filepath.Rel(dir, path)


### PR DESCRIPTION
It's possible users may keep other .key files in this dir
(e.g. cosigning files) if they aren't readable, this causes an
error despite there also being ssl.cert and ssl.key files
available.

Signed-off-by: crozzy <joseph.crosland@gmail.com>

**Issue:** None

**Changelog:** 

**Docs:** 

**Testing:**

```
bash-4.4$ ls -l /conf/stack
total 28
-rwxrwxr-x. 1 118686 118686 2753 Jan  1  1970 config.yaml
-rw-------. 1 118686 118686  649 Sep  2 13:33 cosign.key
-rw-------. 1 118686 118686  178 Sep  2 13:33 cosign.pub
drwxrwxr-x. 2 118686 118686    6 Jan  1  1970 extra_ca_certs
-rwxrwxr-x. 1 118686 118686 1338 Jan  1  1970 ssl.cert
-rwxrwxr-x. 1 118686 118686 1675 Jan  1  1970 ssl.key
```

```
sudo podman run -it --rm -p 80:8080 -p 443:8443     --name=quay    -v $QUAY/config:/conf/stack:Z    -v $QUAY/storage:/datastorage:Z  QUAY_IMAGE
```

```
Certificate ssl.cert is required for HostSettings .
```

**Details:** 

------
(_This section may be deleted._)
**All fields are required.** If a field is not applicable (eg. no relevant CHANGELOG.md), specify "none" or "n/a".

Issue: This is the PROJQUAY jira reference. Pull-request title must start with issue name "PROJQUAY-1234 - ".

Changelog: One line description to be added to CHANGELOG.md during release builds. Typically starts with "Added:", "Fixed:", "Note:", etc.

Docs: Detailed description of changes necessary to docs.projectquay.io. Examples would be addition of config.yaml, indication of UI changes and screenshot impact, and changes in behavior of features.

Testing: Detailed description of how to test changes manually. This section combined with the _Docs_ section above must be sufficiently clear for full test cases to be performed.

Details: Other information meant for pull-request reviewers and developers.
