### PR TITLE
validation: fix postgres root cert validation (PROJQUAY-2414) (#113)

### DIFF
--- a/pkg/lib/fieldgroups/database/database_validator.go
+++ b/pkg/lib/fieldgroups/database/database_validator.go
@@ -1,6 +1,9 @@
 package database
 
 import (
+	"io/ioutil"
+	"os"
+
 	"github.com/quay/config-tool/pkg/lib/shared"
 )
 
@@ -28,8 +31,40 @@ func (fg *DatabaseFieldGroup) Validate(opts shared.Options) []shared.ValidationE
 		ca = fg.DbConnectionArgs.Ssl.Ca
 	}
 
+	sslrootcertTmpPath := fg.DbConnectionArgs.SslRootCert
+	if fg.DbConnectionArgs.SslMode == "verify-full" || fg.DbConnectionArgs.SslMode == "verify-ca" {
+		// Write database.pem needed for db validation, if any, to a temp file
+		tmpCert, err := ioutil.TempFile("/tmp", "database.*.pem")
+		if err != nil {
+			newError := shared.ValidationError{
+				Tags:       []string{"DB_URI"},
+				FieldGroup: fgName,
+				Message:    "Could write database certificate to temporary file. Error: " + err.Error(),
+			}
+			errors = append(errors, newError)
+			return errors
+		}
+
+		defer func() {
+			tmpCert.Close()
+			os.Remove(tmpCert.Name())
+		}()
+
+		if _, err := tmpCert.Write(opts.Certificates["database.pem"]); err != nil {
+			newError := shared.ValidationError{
+				Tags:       []string{"DB_URI"},
+				FieldGroup: fgName,
+				Message:    "Could write database certificate to temporary file. Error: " + err.Error(),
+			}
+			errors = append(errors, newError)
+			return errors
+		}
+
+		sslrootcertTmpPath = tmpCert.Name()
+	}
+
 	// Connect to database
-	err := shared.ValidateDatabaseConnection(opts, fg.DbUri, ca, fg.DbConnectionArgs.Threadlocals, fg.DbConnectionArgs.Autorollback, fg.DbConnectionArgs.SslMode, fg.DbConnectionArgs.SslRootCert, fgName)
+	err := shared.ValidateDatabaseConnection(opts, fg.DbUri, ca, fg.DbConnectionArgs.Threadlocals, fg.DbConnectionArgs.Autorollback, fg.DbConnectionArgs.SslMode, sslrootcertTmpPath, fgName)
 	if err != nil {
 		newError := shared.ValidationError{
 			Tags:       []string{"DB_URI"},

--- a/pkg/lib/shared/validators.go
+++ b/pkg/lib/shared/validators.go
@@ -529,32 +529,15 @@ func ValidateDatabaseConnection(opts Options, rawURI, caCert string, threadlocal
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		// Create connection options
-		dbOpts, err := pgx.ParseConfig(rawURI)
-		if err != nil {
-			return err
-		}
-
 		// If CA cert was included
-		if sslrootcert != "" {
-			certBytes, ok := opts.Certificates["database.pem"]
-			if !ok {
-				return errors.New("could not find database.pem in config bundle")
-			}
-			caCertPool := x509.NewCertPool()
-			if ok := caCertPool.AppendCertsFromPEM(certBytes); !ok {
-				return errors.New("could not add CA cert to pool")
-			}
-			tlsConfig := &tls.Config{
-				InsecureSkipVerify: true,
-				RootCAs:            caCertPool,
-			}
-			dbOpts.TLSConfig = tlsConfig
-		}
-
-		// If no SSL cert is provided
-		if sslrootcert == "" && uri.Query().Get("sslmode") != "required" {
-			dbOpts.TLSConfig = nil
+		// Check if sslmode is either "verify-full" or "verify-ca"
+		// If that's the case, then postgres needs sslrootcert in order to verify
+		// the CA against the server (defaults to ~/.postgresql/root.crt)
+		// In our case, we will temporarily write the database.pem in /tmp
+		// For the actual bundle, the value of sslrootcert should be conf/stack/database.pem
+		// Ref: https://www.postgresql.org/docs/9.1/libpq-ssl.html
+		if sslmode == "verify-full" || sslmode == "verify-ca" {
+			params.Add("sslrootcert", sslrootcert)
 		}
 
 		var dsn string


### PR DESCRIPTION
Temporarily write the root pem to "/tmp". This allows the config-tool
to set sslrootcert to "/tmp/database.pem" in order to validate the
cert when pinging the postgres.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-2414

**Changelog:** 
-Fix postgres certificate validation

Cherrypicked from 04973cc