### PR TITLE
ssl: re-enable .key file loading (PROJQUAY-2511)

### DIFF
--- a/pkg/lib/shared/functions.go
+++ b/pkg/lib/shared/functions.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,6 +12,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // FixInterface converts a map[interface{}]interface{} into a map[string]interface{}
@@ -59,7 +60,7 @@ func LoadCerts(dir string) map[string][]byte {
 	// Get filenames in directory
 	certs := make(map[string][]byte)
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() || strings.Contains(path, "..") || (!strings.HasSuffix(path, ".crt") && !strings.HasSuffix(path, ".cert") && !strings.HasSuffix(path, ".pem")) {
+		if info.IsDir() || strings.Contains(path, "..") || (!strings.HasSuffix(path, ".crt") && !strings.HasSuffix(path, ".cert") && !strings.HasSuffix(path, ".key") && !strings.HasSuffix(path, ".pem")) {
 			return nil
 		}
 
@@ -202,7 +203,7 @@ func GetTlsConfig(opts Options) (*tls.Config, error) {
 	for name, cert := range opts.Certificates {
 		if strings.HasPrefix(name, "extra_ca_certs/") {
 			if ok := rootCAs.AppendCertsFromPEM(cert); !ok {
-				return nil, errors.New("Failed to append custom certificate: " + name)
+				log.Warningf("Could not load extra ca cert file: %s. Skipping.", name)
 			}
 		}
 	}


### PR DESCRIPTION
Due to AppendCertsFromPEM failing when getting .key files
a change was made to stop loading them, this broke the ssl validation
that expects ssl.key and ssl.cert. This change adds back the .key file
loading and just warns if AppendCertsFromPEM cannot load the file
instead of erroring.

Signed-off-by: crozzy <joseph.crosland@gmail.com>

**Issue:** https://issues.redhat.com/browse/PROJQUAY-???
Pull-request title must start with "PROJQUAY-??? - "

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** 

------
(_This section may be deleted._)
**All fields are required.** If a field is not applicable (eg. no relevant CHANGELOG.md), specify "none" or "n/a".

Issue: This is the PROJQUAY jira reference. Pull-request title must start with issue name "PROJQUAY-1234 - ".

Changelog: One line description to be added to CHANGELOG.md during release builds. Typically starts with "Added:", "Fixed:", "Note:", etc.

Docs: Detailed description of changes necessary to docs.projectquay.io. Examples would be addition of config.yaml, indication of UI changes and screenshot impact, and changes in behavior of features.

Testing: Detailed description of how to test changes manually. This section combined with the _Docs_ section above must be sufficiently clear for full test cases to be performed.

Details: Other information meant for pull-request reviewers and developers.
