### PR TITLE
editor: Remove certs from ui scope on select external-tls (PROJQUAY-2628)

### DIFF
--- a/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
+++ b/pkg/lib/editor/js/core-config-setup/config-setup-tool.html
@@ -114,7 +114,7 @@
                 <select ng-disabled="fieldGroupReadonly('HostSettings')" class="form-control" ng-model="mapped.TLS_SETTING">
                   <option value="internal-tls">Red Hat Quay handles TLS</option>
                   <option value="external-tls">My own load balancer handles TLS</option>
-                  <option value="none">None</option>
+                  <option value="none" ng-if="!operatorEndpoint">None</option>
                 </select>
 
                 <table class="config-table" ng-if="mapped.TLS_SETTING == 'internal-tls' && !fieldGroupReadonly('HostSettings')">

--- a/pkg/lib/editor/js/core-config-setup/core-config-setup.js
+++ b/pkg/lib/editor/js/core-config-setup/core-config-setup.js
@@ -604,12 +604,16 @@ angular.module("quay-config")
           switch (value) {
             case 'none':
               $scope.config['PREFERRED_URL_SCHEME'] = 'http';
+              delete $scope.certs["ssl.key"]
+              delete $scope.certs["ssl.cert"]
               delete $scope.config['EXTERNAL_TLS_TERMINATION'];
               return;
 
             case 'external-tls':
               $scope.config['PREFERRED_URL_SCHEME'] = 'https';
               $scope.config['EXTERNAL_TLS_TERMINATION'] = true;
+              delete $scope.certs["ssl.key"];
+              delete $scope.certs["ssl.cert"];
               return;
 
             case 'internal-tls':


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-2528

**Changelog:** 
- Remove certs from ui scope when selecting external tls or no tls
- Only show "None" option when in non-operator deployment

**Docs:** 

**Testing:** 

**Details:** 

------
