### PR TITLE
ldap: Remove validation check for users (PROJQUAY-2343) (#142)

### DIFF
--- a/pkg/lib/shared/validators.go
+++ b/pkg/lib/shared/validators.go
@@ -813,20 +813,12 @@ func ValidateLDAPServer(opts Options, ldapUri, ldapAdminDn, ldapAdminPasswd, lda
 		Controls: []ldap.Control{ldap.NewControlPaging(32)},
 	}
 
-	result, err := l.Search(request)
+	_, err = l.Search(request)
 	if err != nil {
 		return false, ValidationError{
 			Tags:       []string{"LDAP_URI"},
 			FieldGroup: fgName,
 			Message:    "Could not query LDAP server. Error: " + err.Error(),
-		}
-	}
-
-	if len(result.Entries) < 1 {
-		return false, ValidationError{
-			Tags:       []string{"LDAP_URI"},
-			FieldGroup: fgName,
-			Message:    "Could not find any users matching filter in LDAP server",
 		}
 	}
 


### PR DESCRIPTION
The check fails whenever quay is loaded for the first time
and there are no users present

Signed-off-by: harishsurf <hgovinda@redhat.com>
(cherry picked from commit acc3748236b3123fa3ab55faf1d5061eb5d4293c)
