### PR TITLE
s3validation: Pass token during ec2 role auth (PROJQUAY-2983)

### DIFF
--- a/pkg/lib/shared/storage_validators.go
+++ b/pkg/lib/shared/storage_validators.go
@@ -137,6 +137,7 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 
 			accessKey = value.AccessKeyID
 			secretKey = value.SecretAccessKey
+			token = value.SessionToken
 
 		}
 		if ok, err := validateMinioGateway(opts, storageName, endpoint, accessKey, secretKey, bucketName, token, isSecure, fgName); !ok {


### PR DESCRIPTION
When the access and secret key aren't passed during s3 storage validation it will fall back to using ec2 role auth. This will fail with `The AWS Access Key Id you provided does not exist in our records.`. This fix passes the session token so that the auth to s3 can succeed.