### PR TITLE
configtool: Add option to override Azure endpoint (PROJQUAY-891)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8 as jsbuild
+FROM registry.access.redhat.com/ubi8/ubi:latest as jsbuild
 
 WORKDIR /jssrc
 COPY pkg/lib/editor .

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM centos:8 as jsbuild
+FROM registry.access.redhat.com/ubi8/ubi:latest as jsbuild
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/pkg/lib/editor/js/core-config-setup/core-config-setup.js
+++ b/pkg/lib/editor/js/core-config-setup/core-config-setup.js
@@ -91,6 +91,7 @@ angular.module("quay-config")
             {'name': 'azure_account_name', 'title': 'Azure Account Name', 'placeholder': 'accountnamehere', 'kind': 'text'},
             {'name': 'azure_account_key', 'title': 'Azure Account Key',  'placeholder': 'accountkeyhere', 'kind': 'text', 'optional': true},
             {'name': 'sas_token', 'title': 'Azure SAS Token',  'placeholder': 'sastokenhere', 'kind': 'text', 'optional': true},
+            {'name': 'endpoint_url', 'title': 'Azure Storage Endpoint URL',  'placeholder': 'Optional, must include http(s)://', 'kind': 'text', 'optional': true},
           ],
 
           'GoogleCloudStorage': [

--- a/pkg/lib/fieldgroups/distributedstorage/distributedstorage.go
+++ b/pkg/lib/fieldgroups/distributedstorage/distributedstorage.go
@@ -228,6 +228,13 @@ func NewDistributedStorageArgs(storageArgs map[string]interface{}) (*shared.Dist
 		}
 	}
 
+	if value, ok := storageArgs["endpoint_url"]; ok {
+		newDistributedStorageArgs.EndpointURL, ok = value.(string)
+		if !ok {
+			return newDistributedStorageArgs, errors.New("endpoint_url must be of type string")
+		}
+	}
+
 	if value, ok := storageArgs["storage_path"]; ok {
 		newDistributedStorageArgs.StoragePath, ok = value.(string)
 		if !ok {

--- a/pkg/lib/shared/storage_validators.go
+++ b/pkg/lib/shared/storage_validators.go
@@ -187,12 +187,17 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 		accountKey := args.AzureAccountKey
 		containerName := args.AzureContainer
 		token = args.SASToken
+		if args.EndpointURL != "" {
+			endpoint = args.EndpointURL
+		} else {
+			endpoint = fmt.Sprintf("https://%s.blob.core.windows.net", accountName)
+		}
 
 		if len(errors) > 0 {
 			return false, errors
 		}
 
-		if ok, err := validateAzureGateway(opts, storageName, accountName, accountKey, containerName, token, fgName); !ok {
+		if ok, err := validateAzureGateway(opts, endpoint, storageName, accountName, accountKey, containerName, token, fgName); !ok {
 			errors = append(errors, err)
 		}
 
@@ -367,7 +372,7 @@ func validateMinioGateway(opts Options, storageName, endpoint, accessKey, secret
 
 }
 
-func validateAzureGateway(opts Options, storageName, accountName, accountKey, containerName, token, fgName string) (bool, ValidationError) {
+func validateAzureGateway(opts Options, endpointURL, storageName, accountName, accountKey, containerName, token, fgName string) (bool, ValidationError) {
 
 	credentials, err := azblob.NewSharedKeyCredential(accountName, accountKey)
 	if err != nil {
@@ -379,7 +384,7 @@ func validateAzureGateway(opts Options, storageName, accountName, accountKey, co
 	}
 
 	p := azblob.NewPipeline(credentials, azblob.PipelineOptions{})
-	u, err := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net", accountName))
+	u, err := url.Parse(endpointURL)
 
 	serviceURL := azblob.NewServiceURL(*u, p)
 	containerURL := serviceURL.NewContainerURL(containerName)
@@ -399,7 +404,6 @@ func validateAzureGateway(opts Options, storageName, accountName, accountKey, co
 	}
 
 	return true, ValidationError{}
-
 }
 
 func validateSwift(opts Options, storageName string, authVersion int, swiftUser, swiftPassword, containerName, authUrl string, osOptions map[string]interface{}, fgName string) (bool, ValidationError) {

--- a/pkg/lib/shared/structs.go
+++ b/pkg/lib/shared/structs.go
@@ -37,6 +37,7 @@ type DistributedStorageArgs struct {
 	AzureAccountName string `default:"" validate:"" json:"azure_account_name,omitempty" yaml:"azure_account_name,omitempty"`
 	AzureAccountKey  string `default:"" validate:"" json:"azure_account_key,omitempty" yaml:"azure_account_key,omitempty"`
 	SASToken         string `default:"" validate:"" json:"sas_token,omitempty" yaml:"sas_token,omitempty"`
+	EndpointURL      string `default:"" validate:"" json:"endpoint_url,omitempty" yaml:"endpoint_url,omitempty"`
 	// Args for Cloudfront
 	CloudfrontDistributionDomain string `default:"" validate:"" json:"cloudfront_distribution_domain,omitempty" yaml:"cloudfront_distribution_domain,omitempty"`
 	CloudfrontKeyID              string `default:"" validate:"" json:"cloudfront_key_id,omitempty" yaml:"cloudfront_key_id,omitempty"`


### PR DESCRIPTION
Allows overriding the Azure storage endpoint, as an example `accountname.blob.core.usgovcloudapi.net`.