### PR TITLE
smtp: Use TLS certs when connecting to smpt (PROJQUAY-1605)

### DIFF
--- a/pkg/lib/shared/validators.go
+++ b/pkg/lib/shared/validators.go
@@ -695,6 +695,7 @@ func ValidateEmailServer(opts Options, mailServer string, mailPort int, useTLS b
 			}
 
 		}
+		return true, ValidationError{}
 	}
 
 	// If auth is enabled, try to authenticate


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1605

**Changelog:** 
- Use TLS certs when connecting to smtp instead of plain auth

**Docs:** 

**Testing:** 

**Details:** 

------