### PR TITLE
go: Update golang to version 1.16 (PROJQUAY-1605)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum install -y nodejs && \
     npm install --ignore-engines && \
     npm run build
 
-FROM golang:1.15-alpine
+FROM golang:1.16-alpine
 
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/* && mkdir /usr/local/share/ca-certificates/extra
 WORKDIR /go/src/config-tool

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -16,8 +16,8 @@ RUN yum install -y nodejs && \
     npm install --ignore-engines
 
 RUN yum install -y wget && \
-    wget https://golang.org/dl/go1.15.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
+    wget https://golang.org/dl/go1.16.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.16.linux-amd64.tar.gz
 
 WORKDIR /go/src/config-tool
 RUN go get github.com/cosmtrek/air

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/config-tool
 
-go 1.14
+go 1.16
 
 require (
 	cuelang.org/go v0.2.1


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1605

**Changelog:** 
- Update golang version from 1.14 to 1.16

**Docs:** 

**Testing:** 

**Details:** 

------