### PR TITLE
chore: Create PR against Quay for new tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,27 +13,3 @@ jobs:
         with:
           bump_version_scheme: patch
           use_github_release_notes: true
-
-  pull-request-quay:
-    name: "Create Pull Request against Quay repo"
-    runs-on: ubuntu-latest
-    needs: ["release-on-push"]
-    steps:
-      - name: Check out Quay repo
-        uses: actions/checkout@master
-        with:
-          repository: quay/quay
-      - name: Update the version in Quay Dockerfile
-        run: sed -i "s/CONFIGTOOL_VERSION=v.*$/CONFIGTOOL_VERSION=${{ github.event.inputs.tag }}/" Dockerfile
-      - name: Create Pull Request Quay
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.DEPLOY_PAT }}
-          commit-message: "config: Update config tool to ${{ github.event.inputs.tag }}"
-          author: quay-devel <quay-devel@redhat.com>
-          branch: quay/config-tool-pr
-          delete-branch: true
-          signoff: true
-          body: Update config-tool to ${{ github.event.inputs.tag }}
-          committer: quay-devel <quay-devel@redhat.com>
-

--- a/.github/workflows/update-quay.yml
+++ b/.github/workflows/update-quay.yml
@@ -18,7 +18,8 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.DEPLOY_PAT }}
-          commit-message: "config: Update config tool to ${{ github.ref_name }}"
+          title: "build(deps): bump config-tool to ${{ github.ref_name }}"
+          commit-message: "build(deps): bump config-tool to ${{ github.ref_name }}"
           author: quay-devel <quay-devel@redhat.com>
           branch: quay/config-tool-pr
           delete-branch: true

--- a/.github/workflows/update-quay.yml
+++ b/.github/workflows/update-quay.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  pull-request-quay:
+    name: "Create Pull Request against Quay repo"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Quay repo
+        uses: actions/checkout@v3
+        with:
+          repository: quay/quay
+      - name: Update the version in Quay Dockerfile
+        run: sed -i "s/CONFIGTOOL_VERSION=v.*$/CONFIGTOOL_VERSION=${{ github.ref_name }}/" Dockerfile
+      - name: Create Pull Request Quay
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.DEPLOY_PAT }}
+          commit-message: "config: Update config tool to ${{ github.ref_name }}"
+          author: quay-devel <quay-devel@redhat.com>
+          branch: quay/config-tool-pr
+          delete-branch: true
+          signoff: true
+          body: Update config-tool to ${{ github.ref_name }}
+          committer: quay-devel <quay-devel@redhat.com>


### PR DESCRIPTION
Currently `${{ github.event.inputs.tag }}` resolves into an empty string, so the GitHub workflow creates PRs like https://github.com/quay/quay/pull/1999.

This PR makes the pull-request-quay job to run only when a new tag is pushed.