### PR TITLE
validation(database/postgres) add SSL client authentication (PROJQUAY-2417)

### DIFF
--- a/pkg/lib/fieldgroups/database/database.go
+++ b/pkg/lib/fieldgroups/database/database.go
@@ -22,6 +22,22 @@ type DbConnectionArgsStruct struct {
 	// Postgres arguments
 	SslRootCert string `default:""  json:"sslrootcert,omitempty" yaml:"sslrootcert,omitempty"`
 	SslMode     string `default:""  json:"sslmode,omitempty" yaml:"sslmode,omitempty"`
+        SslCert	    string `default:""  json:"sslcert,omitempty" yaml:"sslcert,omitempty"`
+        SslKey      string `default:""  json:"sslkey,omitempty" yaml:"sslkey,omitempty"`
+        SslSni	    string `default:""  json:"sslsni,omitempty" yaml:"sslsni,omitempty"`
+        SslMinProtocolVersion string `default:""  json:"ssl_min_protocol_version,omitempty" yaml:"ssl_min_protocol_version,omitempty"`
+        SslMaxProtocolVersion string `default:""  json:"ssl_max_protocol_version,omitempty" yaml:"ssl_max_protocol_version,omitempty"`
+        SslCrl	    string `default:""  json:"sslcrl,omitempty" yaml:"sslcrl,omitempty"`
+        SslCrlDir   string `default:""  json:"sslcrldir,omitempty" yaml:"sslcrldir,omitempty"`
+        SslCompression int `default:0  json:"sslcompression,omitempty" yaml:"sslcompression,omitempty"`
+
+
+        // Network arguments
+        Keepalives  int `default:0 json:"keepalives,omitempty" yaml:"keepalives,omitempty"`
+        KeepalivesIdle  int `default:10 json:"keepalives_idle,omitempty" yaml:"keepalives_idle,omitempty"`
+        KeepalivesInterval  int `default:2 json:"keepalives_interval,omitempty" yaml:"keepalives_interval,omitempty"`
+        KeepalivesCount  int `default:3 json:"keepalives_count,omitempty" yaml:"keepalives_count,omitempty"`
+        TcpUserTimeout  int `default:0 json:"tcp_user_timeout,omitempty" yaml:"tcp_user_timeout,omitempty"`
 }
 
 // SslStruct represents the SslStruct config fields
@@ -50,6 +66,19 @@ func NewDatabaseFieldGroup(fullConfig map[string]interface{}) (*DatabaseFieldGro
 	}
 
 	return newDatabaseFieldGroup, nil
+}
+
+// function to ensure supported TLS versions are used in Postgres connection URI
+func IsValidTLS(version string) bool {
+	switch version {
+	case
+		"TLSv1",
+		"TLSv1.1",
+		"TLSv1.2",
+		"TLSv1.3":
+		return true
+	}
+	return false
 }
 
 // NewDbConnectionArgsStruct creates a new DbConnectionArgsStruct
@@ -89,6 +118,90 @@ func NewDbConnectionArgsStruct(fullConfig map[string]interface{}) (*DbConnection
 			return newDbConnectionArgsStruct, errors.New("sslrootcert must be of type string")
 		}
 	}
+	if value, ok := fullConfig["sslcert"]; ok {
+                newDbConnectionArgsStruct.SslCert, ok = value.(string)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("sslcert must be of type string")
+                }
+        }
+        if value, ok := fullConfig["sslkey"]; ok {
+                newDbConnectionArgsStruct.SslKey, ok = value.(string)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("sslkey must be of type string")
+                }
+        }
+        if value, ok := fullConfig["sslsni"]; ok {
+                newDbConnectionArgsStruct.SslSni, ok = value.(string)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("sslsni must be of type string")
+                }
+        }
+        if value, ok := fullConfig["ssl_min_protocolversion"]; ok {
+                newDbConnectionArgsStruct.SslMinProtocolVersion, ok = value.(string)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("ssl_min_protoclversion must be of type string")
+                }
+		if !IsValidTLS(value.(string)) {
+			return newDbConnectionArgsStruct, errors.New("ssl_min_protoclversion invalid value (supported TLSv1,TLSv1.1-TLSv1.3)")
+		}
+        }
+        if value, ok := fullConfig["ssl_max_protocolversion"]; ok {
+                newDbConnectionArgsStruct.SslMaxProtocolVersion, ok = value.(string)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("ssl_max_protoclversion must be of type string")
+                }
+                if !IsValidTLS(value.(string)) {
+                        return newDbConnectionArgsStruct, errors.New("ssl_max_protoclversion invalid value (supported TLSv1,TLSv1.1-TLSv1.3)")
+                }
+        }
+	if value, ok := fullConfig["sslcrl"]; ok {
+                newDbConnectionArgsStruct.SslCrl, ok = value.(string)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("sslcrl must be of type string")
+                }
+        }
+	if value, ok := fullConfig["sslcrldir"]; ok {
+                newDbConnectionArgsStruct.SslCrlDir, ok = value.(string)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("sslcrldir must be of type string")
+                }
+        }
+        if value, ok := fullConfig["sslcompression"]; ok {
+                newDbConnectionArgsStruct.SslCompression, ok = value.(int)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("sslcompression must be of type int")
+                }
+        }
+        if value, ok := fullConfig["keepalives"]; ok {
+                newDbConnectionArgsStruct.Keepalives, ok = value.(int)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("keepalives must be of type int")
+                }
+        }
+        if value, ok := fullConfig["keepalives_idle"]; ok {
+                newDbConnectionArgsStruct.KeepalivesIdle, ok = value.(int)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("keepalives_idle must be of type int")
+                }
+        }
+        if value, ok := fullConfig["keepalives_interval"]; ok {
+                newDbConnectionArgsStruct.KeepalivesInterval, ok = value.(int)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("keepalives_interval must be of type int")
+                }
+        }
+        if value, ok := fullConfig["keepalives_count"]; ok {
+                newDbConnectionArgsStruct.KeepalivesCount, ok = value.(int)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("keepalives_count must be of type int")
+                }
+        }
+        if value, ok := fullConfig["tcp_user_timeout"]; ok {
+                newDbConnectionArgsStruct.TcpUserTimeout, ok = value.(int)
+                if !ok {
+                        return newDbConnectionArgsStruct, errors.New("tcp_user_timeout must be of type int")
+                }
+        }
 
 	return newDbConnectionArgsStruct, nil
 }

--- a/pkg/lib/fieldgroups/database/database_validator.go
+++ b/pkg/lib/fieldgroups/database/database_validator.go
@@ -32,35 +32,39 @@ func (fg *DatabaseFieldGroup) Validate(opts shared.Options) []shared.ValidationE
 	}
 
 	sslrootcertTmpPath := fg.DbConnectionArgs.SslRootCert
-	if fg.DbConnectionArgs.SslMode == "verify-full" || fg.DbConnectionArgs.SslMode == "verify-ca" {
-		// Write database.pem needed for db validation, if any, to a temp file
-		tmpCert, err := ioutil.TempFile("/tmp", "database.*.pem")
-		if err != nil {
-			newError := shared.ValidationError{
-				Tags:       []string{"DB_URI"},
-				FieldGroup: fgName,
-				Message:    "Could write database certificate to temporary file. Error: " + err.Error(),
+        if fg.DbConnectionArgs.SslRootCert == "" {
+		if fg.DbConnectionArgs.SslMode == "verify-full" || fg.DbConnectionArgs.SslMode == "verify-ca" {
+			// Write database.pem needed for db validation, if any, to a temp file
+			tmpCert, err := ioutil.TempFile("/tmp", "database.*.pem")
+			if err != nil {
+				newError := shared.ValidationError{
+					Tags:       []string{"DB_URI"},
+					FieldGroup: fgName,
+					Message:    "Could write database certificate to temporary file. Error: " + err.Error(),
+				}
+				errors = append(errors, newError)
+				return errors
 			}
-			errors = append(errors, newError)
-			return errors
-		}
-
-		defer func() {
-			tmpCert.Close()
-			os.Remove(tmpCert.Name())
-		}()
-
-		if _, err := tmpCert.Write(opts.Certificates["database.pem"]); err != nil {
-			newError := shared.ValidationError{
-				Tags:       []string{"DB_URI"},
-				FieldGroup: fgName,
-				Message:    "Could write database certificate to temporary file. Error: " + err.Error(),
+	
+			defer func() {
+				tmpCert.Close()
+				os.Remove(tmpCert.Name())
+			}()
+	
+			if _, err := tmpCert.Write(opts.Certificates["database.pem"]); err != nil {
+				newError := shared.ValidationError{
+					Tags:       []string{"DB_URI"},
+					FieldGroup: fgName,
+					Message:    "Could write database certificate to temporary file. Error: " + err.Error(),
+				}
+				errors = append(errors, newError)
+				return errors
 			}
-			errors = append(errors, newError)
-			return errors
+	
+			sslrootcertTmpPath = tmpCert.Name()
 		}
-
-		sslrootcertTmpPath = tmpCert.Name()
+	} else { 
+		sslrootcertTmpPath = fg.DbConnectionArgs.SslRootCert
 	}
 
 	// Connect to database


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-2417
Pull-request title must start with "[PROJQUAY-2417](https://issues.redhat.com//browse/PROJQUAY-2417) - "

**Changelog:** 
Added SSL client authentication by extending libpg connection parameter support as well as network parameters

**Docs:** 

**Testing:** 
since this change requires a Postgres Database with SSL client authentication setup, I executed the validation run manually after building the image as described in the README.md
I did not setup Redis for the test as I have verified that Quay will be able to use SSL client authentication if validation is turned off to get it started.

**Details:** 

```
/go/src/config-tool # export DEBUGLOG=true
/go/src/config-tool # config-tool validate -c /conf/stack -m online 
DEBU[0000] Validating AccessSettings                    
DEBU[0000] Validating ActionLogArchiving                
DEBU[0000] Validating AppTokenAuthentication            
DEBU[0000] Validating BitbucketBuildTrigger             
DEBU[0000] Validating BuildManager                      
DEBU[0000] Validating Database                          
DEBU[0000] Scheme: postgresql                           
DEBU[0000] Host: cluster-rw.quay.svc:15432      
DEBU[0000] Db: quay                                     
DEBU[0000] Params: sslcert=%2F.postgresql%2Fpostgresql.crt&sslkey=%2F.postgresql%2Fpostgresql.key&sslmode=verify-full&sslrootcert=%2F.postgresql%2Froot.crt 
DEBU[0000] Including params sslcert=%2F.postgresql%2Fpostgresql.crt&sslkey=%2F.postgresql%2Fpostgresql.key&sslmode=verify-full&sslmode=verify-full&sslrootcert=%2F.postgresql%2Froot.crt&sslrootcert=%2F.postgresql%2Froot.crt 
DEBU[0000] Pinging database at postgresql://quay@cluster-rw.quay.svc:15432/quay?sslcert=%2F.postgresql%2Fpostgresql.crt&sslkey=%2F.postgresql%2Fpostgresql.key&sslmode=verify-full&sslmode=verify-full&sslrootcert=%2F.postgresql%2Froot.crt&sslrootcert=%2F.postgresql%2Froot.crt 
plpgsql
pg_stat_statements
pg_trgm
DEBU[0000] Validating DistributedStorage                
DEBU[0000] Validating ElasticSearch                     
DEBU[0000] Validating Email                             
DEBU[0000] Validating GitHubBuildTrigger                
DEBU[0000] Validating GitHubLogin                       
DEBU[0000] Validating GitLabBuildTrigger                
DEBU[0000] Validating GoogleLogin                       
DEBU[0000] Validating HostSettings                      
DEBU[0000] Validating JWTAuthentication                 
DEBU[0000] Validating LDAP                              
DEBU[0000] Validating OIDC                              
DEBU[0001] Validating QuayDocumentation                 
DEBU[0001] Validating Redis                             
DEBU[0001] Address: redis:6379                          
DEBU[0001] Username:                                    
DEBU[0001] Password Len: 8                              
DEBU[0001] Ssl: <nil>                                   
DEBU[0001] Address: redis:6379                          
DEBU[0001] Username:                                    
DEBU[0001] Password Len: 8                              
DEBU[0001] Ssl: <nil>                                   
DEBU[0001] Redis%!(EXTRA string=Could not connect to Redis with values provided in BUILDLOGS_REDIS. Error: dial tcp: lookup redis on 10.0.2.3:53: no such host, []string=[BUILDLOGS_REDIS]) 
DEBU[0001] Redis%!(EXTRA string=Could not connect to Redis with values provided in USER_EVENTS_REDIS. Error: dial tcp: lookup redis on 10.0.2.3:53: no such host, []string=[USER_EVENTS_REDIS]) 
DEBU[0001] Validating RepoMirror                        
DEBU[0001] Validating SecurityScanner                   
DEBU[0001] Validating TeamSyncing                       
DEBU[0001] Validating TimeMachine                       
DEBU[0001] Validating UserVisibleSettings               
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
|      Field Group       |                                                              Error                                                               | Status |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| AccessSettings         | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| ActionLogArchiving     | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| AppTokenAuthentication | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| BitbucketBuildTrigger  | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| BuildManager           | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| Database               | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| DistributedStorage     | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| ElasticSearch          | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| Email                  | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| GitHubBuildTrigger     | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| GitHubLogin            | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| GitLabBuildTrigger     | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| GoogleLogin            | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| HostSettings           | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| JWTAuthentication      | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| LDAP                   | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| OIDC                   | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| QuayDocumentation      | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| Redis                  | Could not connect to Redis with values provided in BUILDLOGS_REDIS. Error: dial tcp: lookup redis on 10.0.2.3:53: no such host   | 🔴     |
+                        +----------------------------------------------------------------------------------------------------------------------------------+--------+
|                        | Could not connect to Redis with values provided in USER_EVENTS_REDIS. Error: dial tcp: lookup redis on 10.0.2.3:53: no such host | 🔴     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| RepoMirror             | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| SecurityScanner        | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| TeamSyncing            | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| TimeMachine            | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
| UserVisibleSettings    | -                                                                                                                                | 🟢     |
+------------------------+----------------------------------------------------------------------------------------------------------------------------------+--------+
```
